### PR TITLE
ci: switch lint and unit-tests to lab runners

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -75,7 +75,7 @@ jobs:
           CUDA_VISIBLE_DEVICES: ""
 
   docker:
-    runs-on: ubuntu-latest
+    runs-on: lab
     steps:
       - uses: actions/checkout@v4
 
@@ -91,8 +91,8 @@ jobs:
           tags: mcp-memory:test
           build-args: |
             CUDA_ENABLED=false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=local,src=/cache/docker
+          cache-to: type=local,dest=/cache/docker,mode=max
 
       - name: Test container starts
         run: |


### PR DESCRIPTION
Switch lint and unit-tests jobs to self-hosted k3s ARC runners (`runs-on: lab`).