### PR TITLE
fix(ci): switch docker cache from GHA to GHCR registry

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -8,6 +8,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   lint:
     runs-on: lab
@@ -82,6 +86,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build image (CPU variant)
         uses: docker/build-push-action@v5
         with:
@@ -91,8 +102,8 @@ jobs:
           tags: mcp-memory:test
           build-args: |
             CUDA_ENABLED=false
-          cache-from: type=local,src=/cache/docker
-          cache-to: type=local,dest=/cache/docker,mode=max
+          cache-from: type=registry,ref=ghcr.io/27b-io/mcp-memory-service:cache-cpu
+          cache-to: type=registry,ref=ghcr.io/27b-io/mcp-memory-service:cache-cpu,mode=max
 
       - name: Test container starts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,5 +83,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             CUDA_ENABLED=${{ matrix.cuda_enabled }}
-          cache-from: type=gha,scope=${{ matrix.variant }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ matrix.variant }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache-${{ matrix.variant }},mode=max


### PR DESCRIPTION
## Summary

- Switch Docker build cache from `type=gha` to `type=registry` using GHCR
- Add GHCR login + `packages:write` permission to QA workflow
- Share `cache-cpu` tag between QA and Release workflows

## Problem

The `type=gha` cache backend was completely broken:

| Metric | Value |
|--------|-------|
| GHA cache usage | 9.8 GB / 10 GB limit |
| Cache hits per build | **0** (zero) |
| Cache export time | **10+ min** per run |
| Actual build time | ~3 min |
| Duplicate blobs | 2x 4.1 GB (QA + Release stored identical content under different scopes) |

The cache manifest was imported successfully each run, but the actual layer blobs (~4 GB each) were being evicted between runs due to the 10 GB repo-wide limit. Every build ran from scratch, then spent 10+ minutes uploading cache that would be evicted before the next run could use it.

## Fix

`type=registry` stores cache layers as OCI manifests in GHCR:
- **No size limit** (uses container registry storage, not Actions cache)
- **Shared across workflows** — QA and Release both read/write `cache-cpu`
- **Faster import** — registry pulls are optimized for container layers
- CUDA variant gets its own `cache-cuda` tag

## Expected impact

- First run: same ~3 min build + cache export (one-time seed)
- Subsequent runs: most layers CACHED, build drops to ~30-60s
- No more 10+ min wasted on cache export to a full GHA cache

## Test plan

- [x] YAML validates (pre-commit `check-yaml` passed)
- [ ] QA workflow succeeds on this PR (will confirm GHCR cache write works)
- [ ] Second push to this PR shows CACHED layers in build output