### PR TITLE
ci: move remaining jobs to lab runners

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -56,7 +56,7 @@ jobs:
           CUDA_VISIBLE_DEVICES: ""
 
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: lab
     timeout-minutes: 45
     if: false  # Disabled for PRs - enable for nightly builds
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
   publish:
     needs: release
     if: ${{ needs.release.outputs.release_created }}
-    runs-on: ubuntu-latest
+    runs-on: lab
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary
- QA integration-tests: `ubuntu-latest` → `lab` (disabled but ready when enabled)
- Release publish (Docker builds): `ubuntu-latest` → `lab`
- Release release-please stays on `ubuntu-latest` (lightweight, no Docker needed)

## Test plan
- [x] QA workflow triggers on this PR to validate lab runner works