### PR TITLE
chore: fix backfill_summaries.py for server-mode Qdrant (#39)

### DIFF
--- a/scripts/backfill_summaries.py
+++ b/scripts/backfill_summaries.py
@@ -1,89 +1,115 @@
 #!/usr/bin/env python3
 """Backfill extractive summaries for existing memories in Qdrant.
 
-Iterates all memories in the collection, generates extractive summaries
-for entries missing them, and updates the Qdrant payload in batch.
+Iterates all memories in the collection using Qdrant's native scroll API,
+generates extractive summaries for entries missing them, and updates the
+Qdrant payload via set_payload.
 
 Idempotent: skips memories that already have a summary.
 
 Usage:
-    uv run --python 3.12 python scripts/backfill_summaries.py [--dry-run] [--batch-size N]
+    MCP_QDRANT_URL=http://... uv run --python 3.12 python scripts/backfill_summaries.py [--dry-run] [--batch-size N]
+    MCP_QDRANT_URL=http://... uv run --python 3.12 python scripts/backfill_summaries.py --url http://localhost:6333
 """
 
 import argparse
-import asyncio
 import logging
+import os
 import sys
 from pathlib import Path
 
-# Add project root to path
+from qdrant_client import QdrantClient
+from qdrant_client.models import PointIdsList
+
+# Add project root to path for summariser import
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from mcp_memory_service.storage.factory import create_storage_instance  # noqa: E402
 from mcp_memory_service.utils.summariser import extract_summary  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
 
+COLLECTION = "memories"
+# Qdrant uses this point ID for internal metadata — skip it
+METADATA_POINT_ID = "00000000-0000-0000-0000-000000000000"
 
-async def backfill(dry_run: bool = False, batch_size: int = 100) -> None:
-    """Run the backfill process."""
-    storage = await create_storage_instance()
 
-    try:
-        stats = {"total": 0, "skipped": 0, "updated": 0, "errors": 0}
+def backfill(client: QdrantClient, dry_run: bool = False, batch_size: int = 100) -> dict:
+    """Run the backfill process using Qdrant's native scroll API.
 
-        # Scroll through all memories in batches
-        offset = 0
-        while True:
-            memories = await storage.get_all_memories(limit=batch_size, offset=offset)
-            if not memories:
-                break
+    Uses offset-based pagination (next_page_offset) which is reliable
+    regardless of duplicate field values.
+    """
+    stats = {"total": 0, "skipped": 0, "updated": 0, "errors": 0}
+    offset = None  # First page
 
-            for memory in memories:
-                stats["total"] += 1
+    while True:
+        points, next_offset = client.scroll(
+            collection_name=COLLECTION,
+            limit=batch_size,
+            offset=offset,
+            with_payload=True,
+            with_vectors=False,
+        )
 
-                # Skip if summary already exists
-                if memory.summary is not None:
-                    stats["skipped"] += 1
-                    continue
+        if not points:
+            break
 
-                # Generate extractive summary
-                summary = extract_summary(memory.content)
-                if summary is None:
-                    stats["skipped"] += 1
-                    continue
+        for point in points:
+            pid = str(point.id)
+            if pid == METADATA_POINT_ID:
+                continue
 
-                if dry_run:
-                    logger.info(f"[DRY RUN] {memory.content_hash[:12]}: {summary[:80]}")
-                    stats["updated"] += 1
-                    continue
+            stats["total"] += 1
+            payload = point.payload or {}
 
-                # Update Qdrant payload with summary
-                try:
-                    await storage.update_memory_metadata(
-                        memory.content_hash,
-                        {"summary": summary},
-                        preserve_timestamps=True,
-                    )
-                    stats["updated"] += 1
-                except Exception as e:
-                    logger.warning(f"Failed to update {memory.content_hash[:12]}: {e}")
-                    stats["errors"] += 1
+            # Skip if summary already exists
+            if payload.get("summary") is not None:
+                stats["skipped"] += 1
+                continue
 
-            offset += batch_size
-            logger.info(
-                f"Progress: {stats['total']} scanned, "
-                f"{stats['updated']} updated, "
-                f"{stats['skipped']} skipped, "
-                f"{stats['errors']} errors"
-            )
+            content = payload.get("content", "")
+            if not content:
+                stats["skipped"] += 1
+                continue
 
-        logger.info(f"Backfill complete: {stats}")
+            # Generate extractive summary
+            summary = extract_summary(content)
+            if summary is None:
+                stats["skipped"] += 1
+                continue
 
-    finally:
-        if hasattr(storage, "close"):
-            await storage.close()
+            content_hash = payload.get("content_hash", pid)[:12]
+
+            if dry_run:
+                logger.info(f"[DRY RUN] {content_hash}: {summary[:80]}")
+                stats["updated"] += 1
+                continue
+
+            # Update Qdrant payload with summary (preserves all existing fields)
+            try:
+                client.set_payload(
+                    collection_name=COLLECTION,
+                    payload={"summary": summary},
+                    points=PointIdsList(points=[point.id]),
+                )
+                stats["updated"] += 1
+            except Exception as e:
+                logger.warning(f"Failed to update {content_hash}: {e}")
+                stats["errors"] += 1
+
+        logger.info(
+            f"Progress: {stats['total']} scanned, "
+            f"{stats['updated']} updated, "
+            f"{stats['skipped']} skipped, "
+            f"{stats['errors']} errors"
+        )
+
+        if next_offset is None:
+            break
+        offset = next_offset
+
+    return stats
 
 
 def main() -> None:
@@ -99,8 +125,34 @@ def main() -> None:
         default=100,
         help="Number of memories to process per batch (default: 100)",
     )
+    parser.add_argument(
+        "--url",
+        type=str,
+        default=None,
+        help="Qdrant server URL (overrides MCP_QDRANT_URL env var)",
+    )
     args = parser.parse_args()
-    asyncio.run(backfill(dry_run=args.dry_run, batch_size=args.batch_size))
+
+    # Resolve Qdrant URL
+    url = args.url or os.environ.get("MCP_QDRANT_URL")
+    if not url:
+        logger.error("No Qdrant URL. Set MCP_QDRANT_URL or use --url")
+        sys.exit(1)
+
+    logger.info(f"Connecting to Qdrant at {url}")
+    client = QdrantClient(url=url, timeout=30)
+
+    # Verify connection
+    info = client.get_collection(COLLECTION)
+    logger.info(f"Collection '{COLLECTION}': {info.points_count} points")
+
+    # Run backfill
+    mode = "DRY RUN" if args.dry_run else "LIVE"
+    logger.info(f"Starting backfill ({mode}, batch_size={args.batch_size})")
+    stats = backfill(client, dry_run=args.dry_run, batch_size=args.batch_size)
+    logger.info(f"Backfill complete: {stats}")
+
+    client.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cherry-picked from polecat branch. Fixes infinite-loop bug in backfill script, uses Qdrant native scroll API. 2,355 memories already backfilled. Closes #39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for URL configuration via `--url` flag and `MCP_QDRANT_URL` environment variable to override default connection settings.

* **Improvements**
  * Enhanced progress reporting with detailed batch statistics (total, updated, skipped, and errors counts).
  * Optimized backfill operation with improved error handling and logging.
  * Pre-processing validation now logs collection information before operations begin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->