### PR TITLE
ci: authenticate Docker Hub in QA docker job

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -90,6 +90,7 @@ jobs:
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
+        if: ${{ secrets.DOCKERHUB_USERNAME && secrets.DOCKERHUB_TOKEN }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/scripts/backfill_summaries.py
+++ b/scripts/backfill_summaries.py
@@ -79,7 +79,7 @@ def backfill(client: QdrantClient, dry_run: bool = False, batch_size: int = 100)
                 stats["skipped"] += 1
                 continue
 
-            content_hash = payload.get("content_hash", pid)[:12]
+            content_hash = str(payload.get("content_hash", pid))[:12]
 
             if dry_run:
                 logger.info(f"[DRY RUN] {content_hash}: {summary[:80]}")
@@ -142,17 +142,18 @@ def main() -> None:
     logger.info(f"Connecting to Qdrant at {url}")
     client = QdrantClient(url=url, timeout=30)
 
-    # Verify connection
-    info = client.get_collection(COLLECTION)
-    logger.info(f"Collection '{COLLECTION}': {info.points_count} points")
+    try:
+        # Verify connection
+        info = client.get_collection(COLLECTION)
+        logger.info(f"Collection '{COLLECTION}': {info.points_count} points")
 
-    # Run backfill
-    mode = "DRY RUN" if args.dry_run else "LIVE"
-    logger.info(f"Starting backfill ({mode}, batch_size={args.batch_size})")
-    stats = backfill(client, dry_run=args.dry_run, batch_size=args.batch_size)
-    logger.info(f"Backfill complete: {stats}")
-
-    client.close()
+        # Run backfill
+        mode = "DRY RUN" if args.dry_run else "LIVE"
+        logger.info(f"Starting backfill ({mode}, batch_size={args.batch_size})")
+        stats = backfill(client, dry_run=args.dry_run, batch_size=args.batch_size)
+        logger.info(f"Backfill complete: {stats}")
+    finally:
+        client.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- QA docker job pulls `python:3.12-slim` from Docker Hub during buildx — unauthenticated
- Same rate limit fix as #37, applied to qa.yml
- Docker Hub login before buildx setup so credentials are available during build

Fixes https://github.com/27b-io/mcp-memory-service/actions/runs/21774603358/job/62828853954

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline updated to authenticate with Docker Hub during container builds.
* **Bug Fixes**
  * Fixed backfill tool to safely handle content-hash values when truncating identifiers.
  * Ensured the backfill process always closes its connection/resources even on errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->