### PR TITLE
ci: drop arm64 from CPU image build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,10 +43,10 @@ jobs:
     strategy:
       matrix:
         include:
-          # CPU build - multi-platform (amd64 + arm64)
+          # CPU build - amd64 only (add linux/arm64 back when needed)
           - variant: cpu
             cuda_enabled: "false"
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
             suffix: ""  # Default tag (no suffix) is CPU
           # CUDA build - amd64 only (CUDA not available on ARM)
           - variant: cuda


### PR DESCRIPTION
amd64-only for now — no arm64 targets in use. Cuts build time significantly (no QEMU cross-compilation). Add arm64 back when needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CPU variant build configuration to support single architecture only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->