### PR TITLE
fix: add Snowflake Arctic Embed v2.0 models to dimension lookup

### DIFF
--- a/src/mcp_memory_service/storage/qdrant_storage.py
+++ b/src/mcp_memory_service/storage/qdrant_storage.py
@@ -272,6 +272,9 @@ class QdrantStorage(MemoryStorage):
             "BAAI/bge-large-en-v1.5": 1024,
             "infgrad/stella-base-en-v2": 768,
             "nomic-ai/nomic-embed-text-v1": 768,  # Assuming 768 based on common practice
+            "Snowflake/snowflake-arctic-embed-l-v2.0": 1024,
+            "Snowflake/snowflake-arctic-embed-m-v2.0": 768,
+            "Snowflake/snowflake-arctic-embed-s-v2.0": 384,
         }
 
         # Try to get dimensions from known models first


### PR DESCRIPTION
## Problem

`_detect_vector_dimensions()` defaults to 384 for models not in its lookup table. `Snowflake/snowflake-arctic-embed-l-v2.0` produces 1024-dim vectors but wasn't in the table, causing:

```
StorageError: Collection vector size (1024) doesn't match current model dimensions (384).
```

This crashes the service on startup (CrashLoopBackOff).

## Fix

Add all three Arctic Embed v2.0 variants to the dimension lookup:
- `snowflake-arctic-embed-l-v2.0`: 1024
- `snowflake-arctic-embed-m-v2.0`: 768
- `snowflake-arctic-embed-s-v2.0`: 384

One-line fix per model. No migration needed — the model was already producing correct vectors, just the dimension detection was wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility with Snowflake Arctic embedding models (large, medium, and small variants), enabling support for additional embedding options in vector search operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->