### PR TITLE
fix(ci): skip QA docker build on push to main

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -92,6 +92,7 @@ jobs:
           CUDA_VISIBLE_DEVICES: ""
 
   docker:
+    if: github.event_name == 'pull_request'
     runs-on: lab
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

QA's `docker` job builds the image to validate the Dockerfile. On push to main, `release.yml`'s publish job builds and pushes the same image — so QA's docker build is redundant. Every push to main was building the Docker image **twice**.

One-line fix: `if: github.event_name == 'pull_request'` on the docker job.

## Test plan

- [ ] PR push triggers QA with docker job (validates Dockerfile before merge)
- [ ] Push to main triggers QA **without** docker job
- [ ] Push to main triggers Release with publish job (the only Docker build needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow configuration to improve build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->