### PR TITLE
fix(ci): run QA only on pull requests, not push to main

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -3,8 +3,6 @@ name: QA
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -92,7 +90,6 @@ jobs:
           CUDA_VISIBLE_DEVICES: ""
 
   docker:
-    if: github.event_name == 'pull_request'
     runs-on: lab
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

QA validates code on the PR before merge. Running it again on push to main is redundant. This removes the `push` trigger to halve QA workflow runs per release cycle.

**Before** (per release cycle — 6 workflow runs):
| Event | QA | Release | CodeQL |
|-------|-----|---------|--------|
| PR merge → push to main | lint, tests, docker | release-please | scan |
| release-please PR | lint, tests, docker | - | scan |
| release PR merge → push to main | lint, tests, docker | build+push | scan |

**After** (per release cycle — 4 workflow runs):
| Event | QA | Release | CodeQL |
|-------|-----|---------|--------|
| PR merge → push to main | - | release-please | scan |
| release-please PR | lint, tests, docker | - | scan |
| release PR merge → push to main | - | build+push | scan |

Also removes the now-redundant `if: github.event_name == 'pull_request'` guard on the docker job (from PR #60), since QA only triggers on pull_request now.

Also disabled two ghost workflows (bridge-tests, dockerfile-lint) that were deleted from the repo but still registered.

## Test plan

- [ ] PR triggers QA with all jobs (lint, tests, docker)
- [ ] Push to main does NOT trigger QA
- [ ] Release-please PR gets full QA as pre-release gate
- [ ] Release workflow still builds+pushes on main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated QA workflow configuration by adjusting trigger conditions and conditional gates for the docker job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->