### PR TITLE
fix: tag search returns UUID point IDs instead of content hashes

### DIFF
--- a/src/mcp_memory_service/storage/qdrant_storage.py
+++ b/src/mcp_memory_service/storage/qdrant_storage.py
@@ -960,7 +960,7 @@ class QdrantStorage(MemoryStorage):
                 payload = point.payload
                 memory = Memory(
                     content=payload.get("content", ""),
-                    content_hash=str(point.id),
+                    content_hash=payload.get("content_hash", str(point.id)),
                     tags=payload.get("tags", []),
                     memory_type=payload.get("memory_type"),
                     metadata=payload.get("metadata", {}),


### PR DESCRIPTION
## Bug

`search_by_tag()` used `str(point.id)` for `content_hash`, producing UUID-format strings (`0870364e-629c-bcdd-...`) instead of the actual SHA-256 content hash from the Qdrant payload.

## Impact

1. **TOON output corruption**: Tag-matched memories show UUID hashes that can't be used with `delete_memory`, `get_relations`, or `create_relation`
2. **Hebbian edges silently failing**: Graph nodes use SHA-256 hashes, so MERGE queries found no matching nodes — 20 co-access events processed, 0 edges created
3. **Interference detection broken**: Cosine similarity between differently-hashed versions of the same memory was ~0.009 (threshold: 0.7)

## Root Cause

The `retrieve()` search path (line 792) correctly uses:
```python
content_hash=payload.get("content_hash", str(scored_point.id))
```

But `search_by_tag()` (line 963) used:
```python
content_hash=str(point.id)
```

## Fix

One-line change: use `payload.get("content_hash", str(point.id))` consistent with the retrieve path.

## Found by

Testing the graph tools end-to-end after seeding 1,719 :Memory nodes via backfill. Noticed 0 Hebbian edges despite 20 enqueued/processed events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory retrieval to preserve stored content hash values instead of always deriving them from internal identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->