### PR TITLE
fix: Address Copilot review feedback on three-tier memory (PR #76)

### DIFF
--- a/src/mcp_memory_service/mcp_server.py
+++ b/src/mcp_memory_service/mcp_server.py
@@ -721,7 +721,7 @@ async def push_to_sensory_buffer(
 
     The sensory buffer is a ring buffer (~7 items, 1s TTL) that captures raw
     input before the system decides what's important. Items expire quickly and
-    are not persisted. Use `attend_from_sensory` to promote items to working
+    are not persisted. Use `activate_working_memory` to promote items to working
     memory, or `flush_sensory_to_working` to promote all valid items.
 
     Part of Cowan's three-tier memory model:

--- a/src/mcp_memory_service/memory_tiers.py
+++ b/src/mcp_memory_service/memory_tiers.py
@@ -38,7 +38,7 @@ class SensoryItem:
 
     content: str
     metadata: dict[str, Any]
-    timestamp: float = field(default_factory=time.time)
+    timestamp: float = field(default_factory=lambda: time.time())
     tags: list[str] = field(default_factory=list)
     memory_type: str | None = None
 
@@ -51,8 +51,8 @@ class WorkingChunk:
     metadata: dict[str, Any]
     tags: list[str] = field(default_factory=list)
     memory_type: str | None = None
-    created_at: float = field(default_factory=time.time)
-    last_access: float = field(default_factory=time.time)
+    created_at: float = field(default_factory=lambda: time.time())
+    last_access: float = field(default_factory=lambda: time.time())
     access_count: int = 1
 
 
@@ -262,9 +262,12 @@ class WorkingMemory:
                     chunk.memory_type,
                     chunk.metadata,
                 )
-                self._consolidated_keys.add(key)
-                results.append(result)
-                logger.info(f"Consolidated working memory chunk to LTM: {key[:12]} (accesses={chunk.access_count})")
+                if result.get("success", False):
+                    self._consolidated_keys.add(key)
+                    results.append(result)
+                    logger.info(f"Consolidated working memory chunk to LTM: {key[:12]} (accesses={chunk.access_count})")
+                else:
+                    logger.warning(f"Consolidation callback reported failure for chunk {key[:12]}: {result}")
             except Exception as e:
                 logger.warning(f"Failed to consolidate chunk {key[:12]}: {e}")
 

--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -97,7 +97,8 @@ class MemoryService:
             config = settings.three_tier
             if not config.enabled:
                 return
-        except Exception:
+        except (AttributeError, TypeError, ValueError) as exc:
+            logger.warning("Three-tier memory init skipped: %s", exc)
             return
 
         async def _consolidation_callback(


### PR DESCRIPTION
## Summary

Addresses 4 quality issues identified by GitHub Copilot review of PR #76 (three-tier memory model).

## Fixes

### 1. Consolidation Retry Suppression Bug
**Issue:** Consolidation failures were permanently marking chunks as consolidated, suppressing retries.

**Fix:** Check `result.get("success", False)` before adding to `_consolidated_keys`.

```python
# Before: Always marked as consolidated
self._consolidated_keys.add(key)
results.append(result)

# After: Only mark on success
if result.get("success", False):
    self._consolidated_keys.add(key)
    results.append(result)
else:
    logger.warning(f"Consolidation callback reported failure...")
```

**Impact:** Failed consolidations can now retry on subsequent calls.

### 2. Overly Broad Exception Handling
**Issue:** `except Exception:` in `_init_three_tier()` hid configuration errors.

**Fix:** Narrow to specific exceptions with warning log.

```python
# Before: Silent catch-all
except Exception:
    return

# After: Specific types with logging
except (AttributeError, TypeError, ValueError) as exc:
    logger.warning("Three-tier memory init skipped: %s", exc)
    return
```

**Impact:** Better error visibility during initialization.

### 3. Incorrect Tool Reference in Docstring
**Issue:** Docstring referenced non-existent `attend_from_sensory` tool.

**Fix:** Corrected to `activate_working_memory`.

```python
# Before
Use `attend_from_sensory` to promote items to working memory

# After  
Use `activate_working_memory` to promote items to working memory
```

**Impact:** Documentation accuracy.

### 4. Test Flakiness from time.sleep()
**Issue:** Tests used `time.sleep()` which is unreliable in CI environments.

**Fix:** 
- Monkeypatch `time.time()` with fake_time array
- Lambda-wrap `default_factory` to enable module attribute monkeypatching

```python
# Before: Direct reference (not monkeypatchable)
timestamp: float = field(default_factory=time.time)

# After: Lambda wrapper enables monkeypatching
timestamp: float = field(default_factory=lambda: time.time())
```

**Impact:** Tests run faster (3.12s vs 3.34s) and deterministically in CI.

## Testing

- ✅ 33 three-tier memory tests pass (3.12s, faster without sleep)
- ✅ 447 unit tests pass (no regressions, 3.70s)
- ✅ Deterministic test behavior via monkeypatching

## Changes

- `src/mcp_memory_service/memory_tiers.py`: Success check, lambda wrapping (6 insertions, 6 deletions)
- `src/mcp_memory_service/services/memory_service.py`: Narrow exception (2 insertions, 1 deletion)
- `src/mcp_memory_service/mcp_server.py`: Fix docstring (1 insertion, 1 deletion)
- `tests/unit/test_memory_tiers.py`: Monkeypatch time (15 insertions, 6 deletions)

**Total:** 24 insertions, 14 deletions

## Review

- ✅ All tests pass
- ✅ No regressions  
- ✅ Addresses genuine quality concerns
- ✅ No new code debt

**Reviewer:** chrome (refinery agent with merge authority)  
**Closes:** mm-464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during memory initialization with more specific exception catching and graceful degradation.

* **Improvements**
  * Enhanced consolidation processing with proper success/failure state handling and detailed diagnostic logging.
  * Updated timestamp computation to evaluate at instance creation time.

* **Tests**
  * Optimized time-dependent tests to use time simulation instead of delays for faster execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->