### PR TITLE
fix: remove duplicate nomic-embed-text-v1 dict key

### DIFF
--- a/src/mcp_memory_service/storage/qdrant_storage.py
+++ b/src/mcp_memory_service/storage/qdrant_storage.py
@@ -276,7 +276,6 @@ class QdrantStorage(MemoryStorage):
             "Snowflake/snowflake-arctic-embed-m-v2.0": 768,
             "Snowflake/snowflake-arctic-embed-s-v2.0": 384,
             "nomic-ai/nomic-embed-text-v1.5": 768,
-            "nomic-ai/nomic-embed-text-v1": 768,
         }
 
         # Try to get dimensions from known models first


### PR DESCRIPTION
Removes duplicate dict key `nomic-ai/nomic-embed-text-v1` at line 279 of qdrant_storage.py (ruff F601). This was blocking PR #77 (release v11.5.0).