### PR TITLE
chore(eval): suppress RAGAS NonLLM metric deprecation warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,5 @@ markers =
     slow: mark test as slow (can be skipped with -m "not slow")
     asyncio: mark test as async
     llm_judge: requires an LLM judge endpoint (not run by default)
+filterwarnings =
+    ignore:Importing NonLLM.*from 'ragas.metrics' is deprecated:DeprecationWarning

--- a/tests/eval/conftest.py
+++ b/tests/eval/conftest.py
@@ -6,8 +6,6 @@ Provides ground truth loading and storage setup for retrieval quality evaluation
 
 import json
 import os
-import shutil
-import tempfile
 import uuid
 from collections.abc import AsyncGenerator
 from pathlib import Path

--- a/tests/unit/test_hebbian_boost.py
+++ b/tests/unit/test_hebbian_boost.py
@@ -183,8 +183,12 @@ class TestHebbianBoostIntegration:
 
         service = MemoryService(mock_storage, mock_graph, write_queue=None)
         result = await service._retrieve_vector_only(
-            query="test", page=1, page_size=10,
-            tags=None, memory_type=None, min_similarity=None,
+            query="test",
+            page=1,
+            page_size=10,
+            tags=None,
+            memory_type=None,
+            min_similarity=None,
         )
 
         memories = result["memories"]
@@ -230,8 +234,12 @@ class TestHebbianBoostIntegration:
 
         service = MemoryService(mock_storage, mock_graph, write_queue=None)
         result = await service._retrieve_vector_only(
-            query="test", page=1, page_size=10,
-            tags=None, memory_type=None, min_similarity=None,
+            query="test",
+            page=1,
+            page_size=10,
+            tags=None,
+            memory_type=None,
+            min_similarity=None,
         )
 
         memories = result["memories"]
@@ -250,17 +258,19 @@ class TestHebbianBoostIntegration:
 
         mock_storage = AsyncMock()
         mock_storage.count_semantic_search = AsyncMock(return_value=1)
-        mock_storage.retrieve = AsyncMock(
-            return_value=[_make_query_result("hash_a", 0.9)]
-        )
+        mock_storage.retrieve = AsyncMock(return_value=[_make_query_result("hash_a", 0.9)])
 
         mock_graph = AsyncMock()
         mock_graph.spreading_activation = AsyncMock(return_value={})
         service = MemoryService(mock_storage, mock_graph, write_queue=None)
 
         await service._retrieve_vector_only(
-            query="test", page=1, page_size=10,
-            tags=None, memory_type=None, min_similarity=None,
+            query="test",
+            page=1,
+            page_size=10,
+            tags=None,
+            memory_type=None,
+            min_similarity=None,
         )
 
         mock_graph.hebbian_boosts_within.assert_not_called()
@@ -284,8 +294,12 @@ class TestHebbianBoostIntegration:
 
         service = MemoryService(mock_storage, graph_client=None, write_queue=None)
         result = await service._retrieve_vector_only(
-            query="test", page=1, page_size=10,
-            tags=None, memory_type=None, min_similarity=None,
+            query="test",
+            page=1,
+            page_size=10,
+            tags=None,
+            memory_type=None,
+            min_similarity=None,
         )
 
         memories = result["memories"]
@@ -302,20 +316,20 @@ class TestHebbianBoostIntegration:
 
         mock_storage = AsyncMock()
         mock_storage.count_semantic_search = AsyncMock(return_value=1)
-        mock_storage.retrieve = AsyncMock(
-            return_value=[_make_query_result("hash_a", 0.9)]
-        )
+        mock_storage.retrieve = AsyncMock(return_value=[_make_query_result("hash_a", 0.9)])
 
         mock_graph = AsyncMock()
         mock_graph.spreading_activation = AsyncMock(return_value={})
-        mock_graph.hebbian_boosts_within = AsyncMock(
-            side_effect=ConnectionError("FalkorDB down")
-        )
+        mock_graph.hebbian_boosts_within = AsyncMock(side_effect=ConnectionError("FalkorDB down"))
 
         service = MemoryService(mock_storage, mock_graph, write_queue=None)
         result = await service._retrieve_vector_only(
-            query="test", page=1, page_size=10,
-            tags=None, memory_type=None, min_similarity=None,
+            query="test",
+            page=1,
+            page_size=10,
+            tags=None,
+            memory_type=None,
+            min_similarity=None,
         )
 
         memories = result["memories"]


### PR DESCRIPTION
## Summary
- Suppress RAGAS NonLLM metric deprecation warnings via pytest.ini filterwarnings
- Remove unused `shutil` and `tempfile` imports from tests/eval/conftest.py
- Reformat tests/unit/test_hebbian_boost.py to pass ruff format checks

## Test plan
- [x] Ruff lint: all checks passed (0 errors, previously 2)
- [x] Ruff format: 100 files formatted (previously 1 violation)
- [x] Full unit suite: 481 tests pass

Part of #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deprecation warning filter to pytest configuration.
  * Removed unused imports from test modules.

* **Style**
  * Reformatted test method calls for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->