### PR TITLE
fix: improve antonym detection to prevent false positives on compound identifiers

### DIFF
--- a/src/mcp_memory_service/utils/interference.py
+++ b/src/mcp_memory_service/utils/interference.py
@@ -147,8 +147,10 @@ _TEMPORAL_SUPERSESSION_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Pre-compile tokenizer (matches emotional_analysis.py)
-_TOKEN_RE = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+# Pre-compile tokenizer - matches words, preserving compound identifiers
+# Matches: word_chains (snake_case), hyphen-chains (kebab-case), and simple words
+# This prevents false antonym matches in config fields like "allowed_ips", "blocked_until"
+_TOKEN_RE = re.compile(r"[a-z0-9]+(?:[_-][a-z0-9]+)*")
 
 
 def _tokenize(text: str) -> set[str]:

--- a/tests/unit/test_interference.py
+++ b/tests/unit/test_interference.py
@@ -205,6 +205,21 @@ class TestAntonymDetection:
         antonym_signals = [s for s in signals if s.signal_type == "antonym"]
         assert len(antonym_signals) >= 1
 
+    def test_no_false_positive_compound_terms(self):
+        """GitHub #67: Compound terms like 'allowed_ips' should not trigger antonym detection."""
+        new = "anthropic-lb's allowed_ips config feature controls IP filtering"
+        existing = "The system blocked invalid requests at the gateway level"
+        signals = detect_contradiction_signals(
+            new,
+            existing,
+            "hash1",
+            similarity=0.835,
+            min_confidence=0.3,
+        )
+        # These are not contradictory - "allowed_ips" is a config field, not a semantic assertion
+        antonym_signals = [s for s in signals if s.signal_type == "antonym"]
+        assert len(antonym_signals) == 0
+
 
 # ── Temporal supersession tests ───────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Fix tokenizer regex to preserve compound identifiers (`allowed_ips`, `blocked_until`) as single tokens
- Previously, `allowed_ips` was split into `allowed` + `ips`, triggering false antonym matches against `blocked`
- Regex changed from `[a-z0-9]+(?:-[a-z0-9]+)*` to `[a-z0-9]+(?:[_-][a-z0-9]+)*`

## Test plan
- [x] New regression test: compound config terms don't trigger antonym detection
- [x] Full unit suite: 485 tests pass
- [x] Ruff lint/format clean

Fixes #67