### PR TITLE
fix: return cosine similarity scores from hybrid search, not raw RRF

### DIFF
--- a/tests/unit/test_hebbian_boost.py
+++ b/tests/unit/test_hebbian_boost.py
@@ -192,9 +192,9 @@ class TestHebbianBoostIntegration:
         )
 
         memories = result["memories"]
-        # hash_a: 0.9 * (1 + 0.8 * 0.15) = 0.9 * 1.12 = 1.008
+        # hash_a: 0.9 * (1 + 0.8 * 0.15) = 0.9 * 1.12 = 1.008, capped to 1.0
         hash_a = next(m for m in memories if m["content_hash"] == "hash_a")
-        assert hash_a["similarity_score"] == pytest.approx(0.9 * (1 + 0.8 * 0.15))
+        assert hash_a["similarity_score"] == pytest.approx(1.0)
         assert hash_a["hebbian_boost"] == pytest.approx(0.8)
 
         # hash_b: 0.8 * (1 + 0.6 * 0.15) = 0.8 * 1.09 = 0.872


### PR DESCRIPTION
## Summary

- Hybrid search now returns **cosine similarity** as `similarity_score` instead of raw RRF scores (~0.005-0.016)
- RRF still controls result **ordering**; scores are now meaningful on the [0, 1] scale
- Pre-RRF vector fetch uses `min_similarity=0.0` to avoid over-filtering candidates before fusion
- User's `min_similarity` threshold applied **post-fusion**, after all boost layers
- Scores capped at 1.0 after each boost to prevent explosion from stacked multipliers

## Problem

Two bugs in hybrid search scoring:
1. **#105**: Pre-RRF vector fetch passed user's `min_similarity=0.6` to Qdrant, filtering relevant content (cosine 0.4-0.55) before RRF could consider it
2. **#104**: RRF's `1/(k+rank)` with k=60 produces scores ~0.01, stored as `similarity_score` — making `min_similarity=0.6` filter out everything

Evidence: `mode=similar` returned 3 results at 0.42-0.48; `mode=hybrid` returned 1 result at 0.003 for the same query.

## Test plan

- [x] 5 new unit tests verifying cosine-based scores, RRF ordering, tag-only base score, threshold compatibility
- [x] 537 unit tests pass
- [x] ruff check + format clean
- [ ] Deploy and verify hybrid search returns scores > 0.4 for relevant queries

Closes #104, closes #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Applied similarity threshold after fusion/ranking to ensure correct filtering.
  * Capped similarity scores to the 0–1 range so boosted scores don’t exceed 1.0.
  * Ensured tag-only search results receive a small nonzero display score instead of zero.

* **Refactor**
  * Separated ranking (ordering) from display scoring so ordering is preserved while showing cosine-based scores.

* **Tests**
  * Added tests covering cosine-based scoring, tag-only base scores, ordering, and threshold compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->