### PR TITLE
feat: add configurable uvicorn worker count

### DIFF
--- a/src/mcp_memory_service/config.py
+++ b/src/mcp_memory_service/config.py
@@ -189,6 +189,7 @@ class HTTPSettings(BaseSettings):
     http_enabled: bool = Field(default=False)
     http_port: int = Field(default=8000, ge=1024, le=65535)
     http_host: str = Field(default="0.0.0.0")
+    http_workers: int = Field(default=1, ge=1, le=32, description="Number of uvicorn worker processes (env: MCP_HTTP_WORKERS)")
     cors_origins: list[str] = Field(default=[])  # Secure default: no cross-origin access (CWE-942 fix)
     sse_heartbeat: int = Field(default=30, ge=5, le=300, alias="SSE_HEARTBEAT_INTERVAL")
     api_key: SecretStr | None = Field(default=None)
@@ -925,6 +926,7 @@ def __getattr__(name: str):
         "HTTP_ENABLED": lambda: _settings.http.http_enabled,
         "HTTP_PORT": lambda: _settings.http.http_port,
         "HTTP_HOST": lambda: _settings.http.http_host,
+        "HTTP_WORKERS": lambda: _settings.http.http_workers,
         "CORS_ORIGINS": lambda: _settings.http.cors_origins,
         "SSE_HEARTBEAT_INTERVAL": lambda: _settings.http.sse_heartbeat,
         "API_KEY": lambda: _settings.http.api_key.get_secret_value() if _settings.http.api_key else None,

--- a/src/mcp_memory_service/unified_server.py
+++ b/src/mcp_memory_service/unified_server.py
@@ -43,11 +43,12 @@ class UnifiedServer:
         """Initialize unified server with configuration from environment."""
         import os
 
-        from mcp_memory_service.config import HTTP_ENABLED, HTTP_HOST, HTTP_PORT
+        from mcp_memory_service.config import HTTP_ENABLED, HTTP_HOST, HTTP_PORT, HTTP_WORKERS
 
         self.http_enabled = HTTP_ENABLED
         self.http_host = HTTP_HOST
         self.http_port = HTTP_PORT
+        self.http_workers = HTTP_WORKERS
 
         # MCP transport mode is read directly from environment (not in Settings)
         self.mcp_transport = os.getenv("MCP_TRANSPORT_MODE", "")
@@ -67,7 +68,8 @@ class UnifiedServer:
 
         logger.info("Configuration validated successfully")
         if self.http_enabled:
-            logger.info(f"  HTTP interface: {self.http_host}:{self.http_port}")
+            workers_info = f" ({self.http_workers} workers)" if self.http_workers > 1 else ""
+            logger.info(f"  HTTP interface: {self.http_host}:{self.http_port}{workers_info}")
         if self.mcp_enabled:
             logger.info(f"  MCP interface: {self.mcp_transport} transport")
 
@@ -88,6 +90,7 @@ class UnifiedServer:
                 app,
                 host=self.http_host,
                 port=self.http_port,
+                workers=self.http_workers if self.http_workers > 1 else None,
                 log_config=None,  # Use existing logging config
             )
             server = uvicorn.Server(config)


### PR DESCRIPTION
## Summary

- Adds `MCP_HTTP_WORKERS` env var to configure uvicorn worker processes (default: 1, max: 32)
- Multiple workers fork separate processes, bypassing the GIL for CPU-bound embedding computation
- Default of 1 preserves existing single-process behavior

## Test plan

- [x] All 154 existing tests pass (1 pre-existing failure unrelated)
- [x] Ruff lint + format clean
- [ ] Deploy with `MCP_HTTP_WORKERS=2`, verify multiple uvicorn processes via `ps`
- [ ] Confirm concurrent store requests are no longer serialized on embedding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable HTTP worker process setting (1-32 workers, default 1) controllable via `MCP_HTTP_WORKERS` environment variable
  * HTTP server startup logging now displays worker count when configured with multiple workers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->