### PR TITLE
fix: clean up test import nits

### DIFF
--- a/tests/unit/test_query_intent.py
+++ b/tests/unit/test_query_intent.py
@@ -12,7 +12,7 @@ try:
     spacy.load("en_core_web_sm")
     _spacy_model_available = True
 except (ImportError, OSError):
-    pass
+    pass  # Model not installed — tests requiring it will be skipped
 
 needs_spacy_model = pytest.mark.skipif(not _spacy_model_available, reason="en_core_web_sm not installed")
 
@@ -121,10 +121,9 @@ def test_fallback_analyzer_empty_query_returns_empty_sub_queries():
 def test_get_analyzer_returns_instance():
     """get_analyzer() returns a working analyzer (spaCy or fallback)."""
     import mcp_memory_service.utils.query_intent as mod
-    from mcp_memory_service.utils.query_intent import get_analyzer
 
     mod._analyzer = None
 
-    analyzer = get_analyzer()
+    analyzer = mod.get_analyzer()
     result = analyzer.analyze("test query for analysis")
     assert result.original_query == "test query for analysis"


### PR DESCRIPTION
## Summary
- Add explanatory comment to bare `except/pass` block in `test_query_intent.py`
- Remove dual import style (`import mod` + `from mod import`) flagged by code-quality bot

Followup from PR #112 review comments.

## Test plan
- [x] `pytest tests/unit/test_query_intent.py` — 11 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Internal refactoring of test implementation with no changes to functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->