### PR TITLE
fix: lower default min_similarity to 0.3, add filtered_below_threshold hint

### DIFF
--- a/src/mcp_memory_service/mcp_server.py
+++ b/src/mcp_memory_service/mcp_server.py
@@ -270,7 +270,7 @@ async def search(
     k: int = 10,
     page: int = 1,
     page_size: int = 10,
-    min_similarity: float = 0.5,
+    min_similarity: float = 0.3,
     output: str = "full",
     memory_type: str | None = None,
     encoding_context: dict[str, Any] | None = None,
@@ -291,7 +291,7 @@ async def search(
         k: Max results for "scan" and "similar" modes (default: 10)
         page: Page number, 1-indexed (default: 1)
         page_size: Results per page (default: 10, max: 100)
-        min_similarity: Similarity threshold 0.0-1.0 (default: 0.5). Higher=stricter.
+        min_similarity: Similarity threshold 0.0-1.0 (default: 0.3). Higher=stricter.
         output: "full" (default), "summary" (token-efficient ~50-token summaries), or "both". Applies to scan mode.
         memory_type: Filter by type for "recent" mode (note/decision/task/reference)
         encoding_context: Context-dependent retrieval boost (time_of_day, day_type, agent, task_tags)

--- a/tests/unit/test_min_similarity_default.py
+++ b/tests/unit/test_min_similarity_default.py
@@ -1,12 +1,13 @@
-"""Verify default min_similarity is 0.5 after v11.10.0 cosine score fix."""
+"""Verify default min_similarity is 0.3 after #115 threshold reduction."""
 
 import ast
 from pathlib import Path
 
 
-def test_default_min_similarity_is_0_5():
-    """Default min_similarity should be 0.5, not 0.6.
+def test_default_min_similarity_is_0_3():
+    """Default min_similarity should be 0.3 (lowered from 0.5 in #115).
 
+    0.5 was too strict — silently dropped relevant results for short/fuzzy queries.
     Parses the AST to check the default value directly, avoiding
     FastMCP tool wrapper complexity.
     """
@@ -21,7 +22,7 @@ def test_default_min_similarity_is_0_5():
             ):
                 if arg.arg == "min_similarity":
                     assert isinstance(default, ast.Constant)
-                    assert default.value == 0.5, f"Expected 0.5, got {default.value}"
+                    assert default.value == 0.3, f"Expected 0.3, got {default.value}"
                     return
 
     raise AssertionError("Could not find min_similarity parameter in search function")


### PR DESCRIPTION
## Summary

- Lower default `min_similarity` from 0.5 to 0.3 — 0.5 was too strict and silently dropped relevant results for short/fuzzy queries
- Add `filtered_below_threshold` field to hybrid and vector-only search responses when results are filtered, so callers know memories exist below their threshold

## Test plan

- [x] Updated AST-based default value test to assert 0.3
- [x] Added `TestFilteredBelowThreshold` with 2 tests (reports count when filtering, omits key when nothing filtered)
- [x] All 611 unit tests pass
- [x] Lint + format clean

Closes #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search results now include a count of items filtered below the similarity threshold.

* **Improvements**
  * Lowered the default similarity threshold for search from 0.5 to 0.3, providing broader search result coverage by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->