### PR TITLE
feat: memory deduplication engine with fuzzy matching and merge strategies

### DIFF
--- a/src/mcp_memory_service/utils/deduplication.py
+++ b/src/mcp_memory_service/utils/deduplication.py
@@ -1,0 +1,311 @@
+"""
+Memory deduplication engine.
+
+Detects near-duplicate memories using embedding cosine similarity and optional
+fuzzy text matching, then groups them into clusters using Union-Find for
+efficient O(n α(n)) grouping.
+
+Design rationale:
+    Exact duplicates are already prevented by Qdrant's content_hash-based upserts.
+    This engine targets *semantic* duplicates: memories that express the same
+    information in different words. High embedding similarity (≥0.95 by default)
+    is the primary signal; difflib fuzzy ratio is a cheap secondary signal that
+    requires no extra dependencies.
+
+    Union-Find groups transitive duplicates correctly: if A≈B and B≈C, all three
+    land in the same cluster rather than two overlapping pairs.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from typing import Any
+
+from ..models.memory import Memory
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DuplicatePair:
+    """A detected near-duplicate pair."""
+
+    hash_a: str
+    hash_b: str
+    embedding_similarity: float
+    fuzzy_similarity: float | None = None  # None if not computed
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "hash_a": self.hash_a,
+            "hash_b": self.hash_b,
+            "embedding_similarity": round(self.embedding_similarity, 4),
+        }
+        if self.fuzzy_similarity is not None:
+            d["fuzzy_similarity"] = round(self.fuzzy_similarity, 4)
+        return d
+
+
+@dataclass
+class DuplicateGroup:
+    """A cluster of near-duplicate memories."""
+
+    # All content hashes in this group
+    hashes: list[str]
+    # The representative pair that triggered the grouping (highest similarity)
+    max_similarity: float
+    # Recommended canonical hash based on selection strategy
+    canonical_hash: str | None = None
+    # The Memory objects (populated when requested)
+    memories: list[Memory] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "hashes": self.hashes,
+            "max_similarity": round(self.max_similarity, 4),
+            "canonical_hash": self.canonical_hash,
+            "size": len(self.hashes),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Cosine similarity (no numpy dependency — pure Python for portability)
+# ---------------------------------------------------------------------------
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+    if len(a) != len(b):
+        raise ValueError(f"Vector dimension mismatch: {len(a)} vs {len(b)}")
+    dot = sum(x * y for x, y in zip(a, b))
+    mag_a = math.sqrt(sum(x * x for x in a))
+    mag_b = math.sqrt(sum(y * y for y in b))
+    if mag_a == 0.0 or mag_b == 0.0:
+        return 0.0
+    return dot / (mag_a * mag_b)
+
+
+def fuzzy_similarity(text_a: str, text_b: str) -> float:
+    """Compute fuzzy text similarity using difflib SequenceMatcher."""
+    return SequenceMatcher(None, text_a.lower(), text_b.lower()).ratio()
+
+
+# ---------------------------------------------------------------------------
+# Union-Find for transitive closure grouping
+# ---------------------------------------------------------------------------
+
+
+class _UnionFind:
+    """Path-compressed Union-Find for grouping duplicate clusters."""
+
+    def __init__(self) -> None:
+        self._parent: dict[str, str] = {}
+        self._rank: dict[str, int] = {}
+
+    def find(self, x: str) -> str:
+        if x not in self._parent:
+            self._parent[x] = x
+            self._rank[x] = 0
+        if self._parent[x] != x:
+            self._parent[x] = self.find(self._parent[x])  # path compression
+        return self._parent[x]
+
+    def union(self, x: str, y: str) -> None:
+        rx, ry = self.find(x), self.find(y)
+        if rx == ry:
+            return
+        # Union by rank
+        if self._rank[rx] < self._rank[ry]:
+            rx, ry = ry, rx
+        self._parent[ry] = rx
+        if self._rank[rx] == self._rank[ry]:
+            self._rank[rx] += 1
+
+
+# ---------------------------------------------------------------------------
+# Core deduplication logic
+# ---------------------------------------------------------------------------
+
+
+def find_duplicate_pairs(
+    memories: list[Memory],
+    embeddings: list[list[float]],
+    similarity_threshold: float = 0.95,
+    fuzzy_threshold: float | None = None,
+) -> list[DuplicatePair]:
+    """
+    Find near-duplicate pairs from a list of memories and their embeddings.
+
+    Args:
+        memories: List of Memory objects (order must match embeddings)
+        embeddings: Pre-computed embedding vectors (one per memory)
+        similarity_threshold: Minimum cosine similarity to flag as duplicate (0.0–1.0)
+        fuzzy_threshold: Optional fuzzy text similarity gate (0.0–1.0).
+            When set, a pair is only flagged if BOTH embedding and fuzzy
+            similarity meet their respective thresholds. Useful for suppressing
+            false positives where two short memories happen to be close in
+            embedding space but differ in wording.
+
+    Returns:
+        List of DuplicatePair objects sorted by descending embedding_similarity
+    """
+    if len(memories) != len(embeddings):
+        raise ValueError("memories and embeddings must have the same length")
+
+    pairs: list[DuplicatePair] = []
+    n = len(memories)
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            # Skip pairs with the same content hash (exact duplicates handled elsewhere)
+            if memories[i].content_hash == memories[j].content_hash:
+                continue
+
+            emb_sim = cosine_similarity(embeddings[i], embeddings[j])
+            if emb_sim < similarity_threshold:
+                continue
+
+            fuzz_sim: float | None = None
+            if fuzzy_threshold is not None:
+                fuzz_sim = fuzzy_similarity(memories[i].content, memories[j].content)
+                if fuzz_sim < fuzzy_threshold:
+                    continue
+
+            pairs.append(
+                DuplicatePair(
+                    hash_a=memories[i].content_hash,
+                    hash_b=memories[j].content_hash,
+                    embedding_similarity=emb_sim,
+                    fuzzy_similarity=fuzz_sim,
+                )
+            )
+
+    pairs.sort(key=lambda p: p.embedding_similarity, reverse=True)
+    return pairs
+
+
+def group_duplicate_pairs(pairs: list[DuplicatePair]) -> list[list[str]]:
+    """
+    Group duplicate pairs into transitive clusters using Union-Find.
+
+    Example: if A≈B and B≈C, returns [[A, B, C]] rather than [[A,B], [B,C]].
+
+    Args:
+        pairs: List of DuplicatePair objects
+
+    Returns:
+        List of clusters, each cluster is a list of content hashes.
+        Only clusters with ≥2 members are returned.
+    """
+    uf = _UnionFind()
+    for pair in pairs:
+        uf.union(pair.hash_a, pair.hash_b)
+
+    # Collect groups
+    groups: dict[str, list[str]] = {}
+    all_hashes = {h for pair in pairs for h in (pair.hash_a, pair.hash_b)}
+    for h in all_hashes:
+        root = uf.find(h)
+        groups.setdefault(root, []).append(h)
+
+    return [sorted(members) for members in groups.values() if len(members) >= 2]
+
+
+def select_canonical(
+    memories: list[Memory],
+    strategy: str = "keep_newest",
+) -> str:
+    """
+    Select the canonical memory hash from a duplicate group.
+
+    Args:
+        memories: Memory objects in the group
+        strategy: One of:
+            - "keep_newest": memory with latest created_at wins
+            - "keep_oldest": memory with earliest created_at wins
+            - "keep_most_accessed": memory with highest access_count wins
+
+    Returns:
+        content_hash of the chosen canonical memory
+
+    Raises:
+        ValueError: If strategy is unknown or memories list is empty
+    """
+    if not memories:
+        raise ValueError("memories list is empty")
+
+    if strategy == "keep_newest":
+        canonical = max(memories, key=lambda m: m.created_at or 0.0)
+    elif strategy == "keep_oldest":
+        canonical = min(memories, key=lambda m: m.created_at or 0.0)
+    elif strategy == "keep_most_accessed":
+        canonical = max(memories, key=lambda m: m.access_count)
+    else:
+        raise ValueError(f"Unknown strategy: {strategy!r}. Use 'keep_newest', 'keep_oldest', or 'keep_most_accessed'")
+
+    return canonical.content_hash
+
+
+def build_duplicate_groups(
+    memories: list[Memory],
+    embeddings: list[list[float]],
+    similarity_threshold: float = 0.95,
+    fuzzy_threshold: float | None = None,
+    strategy: str = "keep_newest",
+) -> list[DuplicateGroup]:
+    """
+    Full pipeline: find pairs → cluster → select canonicals → return DuplicateGroups.
+
+    Args:
+        memories: Memory objects (must match embeddings order)
+        embeddings: Pre-computed embedding vectors
+        similarity_threshold: Cosine similarity threshold (default 0.95)
+        fuzzy_threshold: Optional fuzzy text gate (default None = disabled)
+        strategy: Canonical selection strategy (default "keep_newest")
+
+    Returns:
+        List of DuplicateGroup objects, each with canonical_hash set
+    """
+    pairs = find_duplicate_pairs(memories, embeddings, similarity_threshold, fuzzy_threshold)
+    if not pairs:
+        return []
+
+    clusters = group_duplicate_pairs(pairs)
+
+    # Index memories by hash for O(1) lookup
+    mem_by_hash = {m.content_hash: m for m in memories}
+
+    # Build max_similarity per cluster from pairs
+    pair_sim: dict[tuple[str, str], float] = {}
+    for p in pairs:
+        key = (min(p.hash_a, p.hash_b), max(p.hash_a, p.hash_b))
+        pair_sim[key] = max(pair_sim.get(key, 0.0), p.embedding_similarity)
+
+    groups: list[DuplicateGroup] = []
+    for cluster in clusters:
+        cluster_mems = [mem_by_hash[h] for h in cluster if h in mem_by_hash]
+
+        # Max similarity within cluster
+        max_sim = 0.0
+        for i in range(len(cluster)):
+            for j in range(i + 1, len(cluster)):
+                key = (min(cluster[i], cluster[j]), max(cluster[i], cluster[j]))
+                max_sim = max(max_sim, pair_sim.get(key, 0.0))
+
+        canonical = select_canonical(cluster_mems, strategy)
+        groups.append(
+            DuplicateGroup(
+                hashes=cluster,
+                max_similarity=max_sim,
+                canonical_hash=canonical,
+                memories=cluster_mems,
+            )
+        )
+
+    # Sort groups by descending max_similarity
+    groups.sort(key=lambda g: g.max_similarity, reverse=True)
+    return groups

--- a/tests/unit/test_deduplication.py
+++ b/tests/unit/test_deduplication.py
@@ -1,0 +1,318 @@
+"""
+Unit tests for the memory deduplication engine.
+
+Covers:
+- cosine_similarity correctness and edge cases
+- fuzzy_similarity wraps difflib correctly
+- find_duplicate_pairs detects near-duplicates, respects thresholds
+- group_duplicate_pairs (Union-Find) produces transitive clusters
+- select_canonical implements each strategy correctly
+- build_duplicate_groups full pipeline integration
+"""
+
+import math
+
+import pytest
+
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.utils.deduplication import (
+    DuplicatePair,
+    _UnionFind,
+    build_duplicate_groups,
+    cosine_similarity,
+    find_duplicate_pairs,
+    fuzzy_similarity,
+    group_duplicate_pairs,
+    select_canonical,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _memory(content: str, content_hash: str, created_at: float = 1_000_000.0, access_count: int = 0) -> Memory:
+    return Memory(
+        content=content,
+        content_hash=content_hash,
+        created_at=created_at,
+        access_count=access_count,
+    )
+
+
+def _unit_vec(n: int, idx: int) -> list[float]:
+    """Return a unit vector in dimension n with 1.0 at position idx."""
+    v = [0.0] * n
+    v[idx] = 1.0
+    return v
+
+
+def _lerp_vec(a: list[float], b: list[float], t: float) -> list[float]:
+    """Linearly interpolate between two vectors and normalise."""
+    v = [a[i] * (1 - t) + b[i] * t for i in range(len(a))]
+    mag = math.sqrt(sum(x * x for x in v))
+    return [x / mag for x in v]
+
+
+# ---------------------------------------------------------------------------
+# cosine_similarity
+# ---------------------------------------------------------------------------
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors(self):
+        v = [1.0, 2.0, 3.0]
+        assert cosine_similarity(v, v) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors(self):
+        assert cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+    def test_opposite_vectors(self):
+        assert cosine_similarity([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(-1.0)
+
+    def test_zero_vector_returns_zero(self):
+        assert cosine_similarity([0.0, 0.0], [1.0, 0.0]) == 0.0
+
+    def test_dimension_mismatch_raises(self):
+        with pytest.raises(ValueError, match="dimension mismatch"):
+            cosine_similarity([1.0, 2.0], [1.0])
+
+    def test_known_similarity(self):
+        a = [3.0, 4.0]
+        b = [4.0, 3.0]
+        # dot = 12+12=24, |a|=5, |b|=5 → 24/25
+        assert cosine_similarity(a, b) == pytest.approx(24 / 25)
+
+
+# ---------------------------------------------------------------------------
+# fuzzy_similarity
+# ---------------------------------------------------------------------------
+
+
+class TestFuzzySimilarity:
+    def test_identical_strings(self):
+        assert fuzzy_similarity("hello world", "hello world") == pytest.approx(1.0)
+
+    def test_empty_strings(self):
+        assert fuzzy_similarity("", "") == pytest.approx(1.0)
+
+    def test_completely_different(self):
+        score = fuzzy_similarity("aaa", "zzz")
+        assert score == pytest.approx(0.0)
+
+    def test_case_insensitive(self):
+        assert fuzzy_similarity("Hello", "hello") == pytest.approx(1.0)
+
+    def test_partial_overlap(self):
+        score = fuzzy_similarity("the cat sat", "the dog sat")
+        assert 0.0 < score < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Union-Find
+# ---------------------------------------------------------------------------
+
+
+class TestUnionFind:
+    def test_find_returns_self_for_new_node(self):
+        uf = _UnionFind()
+        assert uf.find("a") == "a"
+
+    def test_union_merges_groups(self):
+        uf = _UnionFind()
+        uf.union("a", "b")
+        assert uf.find("a") == uf.find("b")
+
+    def test_transitive_union(self):
+        uf = _UnionFind()
+        uf.union("a", "b")
+        uf.union("b", "c")
+        assert uf.find("a") == uf.find("c")
+
+    def test_independent_groups_remain_separate(self):
+        uf = _UnionFind()
+        uf.union("a", "b")
+        uf.union("c", "d")
+        assert uf.find("a") != uf.find("c")
+
+
+# ---------------------------------------------------------------------------
+# find_duplicate_pairs
+# ---------------------------------------------------------------------------
+
+
+class TestFindDuplicatePairs:
+    def test_identical_embeddings_flagged(self):
+        v = [1.0, 0.0, 0.0]
+        memories = [_memory("content a", "h1"), _memory("content b", "h2")]
+        embeddings = [v, v]
+        pairs = find_duplicate_pairs(memories, embeddings, similarity_threshold=0.95)
+        assert len(pairs) == 1
+        assert pairs[0].embedding_similarity == pytest.approx(1.0)
+
+    def test_orthogonal_embeddings_not_flagged(self):
+        memories = [_memory("a", "h1"), _memory("b", "h2")]
+        embeddings = [[1.0, 0.0], [0.0, 1.0]]
+        pairs = find_duplicate_pairs(memories, embeddings, similarity_threshold=0.95)
+        assert pairs == []
+
+    def test_same_hash_skipped(self):
+        v = [1.0, 0.0]
+        memories = [_memory("a", "same"), _memory("b", "same")]
+        embeddings = [v, v]
+        pairs = find_duplicate_pairs(memories, embeddings, similarity_threshold=0.0)
+        assert pairs == []
+
+    def test_fuzzy_threshold_gates_pair(self):
+        # Embeddings very similar but content very different
+        v1 = [1.0, 0.0]
+        v2 = _lerp_vec([1.0, 0.0], [0.0, 1.0], 0.01)  # similarity ≈ 0.9999
+        memories = [_memory("abc", "h1"), _memory("xyz", "h2")]
+        embeddings = [v1, v2]
+        # Without fuzzy threshold: flagged
+        pairs_no_fuzzy = find_duplicate_pairs(memories, embeddings, similarity_threshold=0.95, fuzzy_threshold=None)
+        assert len(pairs_no_fuzzy) == 1
+        # With strict fuzzy threshold: filtered out
+        pairs_with_fuzzy = find_duplicate_pairs(memories, embeddings, similarity_threshold=0.95, fuzzy_threshold=0.8)
+        assert len(pairs_with_fuzzy) == 0
+
+    def test_results_sorted_descending(self):
+        v0 = [1.0, 0.0, 0.0]
+        v1 = [1.0, 0.0, 0.0]  # identical to v0
+        v2 = _lerp_vec([1.0, 0.0, 0.0], [0.0, 1.0, 0.0], 0.1)  # slightly less similar
+        memories = [_memory("a", "h1"), _memory("b", "h2"), _memory("c", "h3")]
+        embeddings = [v0, v1, v2]
+        pairs = find_duplicate_pairs(memories, embeddings, similarity_threshold=0.9)
+        sims = [p.embedding_similarity for p in pairs]
+        assert sims == sorted(sims, reverse=True)
+
+    def test_mismatched_lengths_raise(self):
+        with pytest.raises(ValueError):
+            find_duplicate_pairs([_memory("a", "h1")], [[1.0], [2.0]], similarity_threshold=0.9)
+
+
+# ---------------------------------------------------------------------------
+# group_duplicate_pairs
+# ---------------------------------------------------------------------------
+
+
+class TestGroupDuplicatePairs:
+    def test_single_pair_becomes_two_member_group(self):
+        pairs = [DuplicatePair("h1", "h2", 0.97)]
+        groups = group_duplicate_pairs(pairs)
+        assert len(groups) == 1
+        assert set(groups[0]) == {"h1", "h2"}
+
+    def test_transitive_grouping(self):
+        # A-B and B-C should produce one group {A, B, C}
+        pairs = [DuplicatePair("A", "B", 0.98), DuplicatePair("B", "C", 0.97)]
+        groups = group_duplicate_pairs(pairs)
+        assert len(groups) == 1
+        assert set(groups[0]) == {"A", "B", "C"}
+
+    def test_two_independent_clusters(self):
+        pairs = [DuplicatePair("A", "B", 0.98), DuplicatePair("C", "D", 0.97)]
+        groups = group_duplicate_pairs(pairs)
+        assert len(groups) == 2
+
+    def test_empty_pairs_returns_empty(self):
+        assert group_duplicate_pairs([]) == []
+
+
+# ---------------------------------------------------------------------------
+# select_canonical
+# ---------------------------------------------------------------------------
+
+
+class TestSelectCanonical:
+    def _make_group(self):
+        return [
+            _memory("oldest content", "h_oldest", created_at=1000.0, access_count=5),
+            _memory("newest content", "h_newest", created_at=3000.0, access_count=2),
+            _memory("most accessed", "h_accessed", created_at=2000.0, access_count=10),
+        ]
+
+    def test_keep_newest(self):
+        assert select_canonical(self._make_group(), "keep_newest") == "h_newest"
+
+    def test_keep_oldest(self):
+        assert select_canonical(self._make_group(), "keep_oldest") == "h_oldest"
+
+    def test_keep_most_accessed(self):
+        assert select_canonical(self._make_group(), "keep_most_accessed") == "h_accessed"
+
+    def test_unknown_strategy_raises(self):
+        with pytest.raises(ValueError, match="Unknown strategy"):
+            select_canonical(self._make_group(), "unknown")
+
+    def test_empty_memories_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            select_canonical([], "keep_newest")
+
+
+# ---------------------------------------------------------------------------
+# build_duplicate_groups (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDuplicateGroups:
+    def test_no_duplicates_returns_empty(self):
+        n = 4
+        memories = [_memory(f"content {i}", f"h{i}") for i in range(n)]
+        # Orthogonal embeddings — no duplicates
+        embeddings = [_unit_vec(n, i) for i in range(n)]
+        groups = build_duplicate_groups(memories, embeddings, similarity_threshold=0.95)
+        assert groups == []
+
+    def test_duplicate_pair_detected(self):
+        v = [1.0, 0.0]
+        memories = [
+            _memory("The project uses Python", "h1", created_at=1000.0),
+            _memory("The project uses Python.", "h2", created_at=2000.0),
+        ]
+        embeddings = [v, v]
+        groups = build_duplicate_groups(memories, embeddings, similarity_threshold=0.95, strategy="keep_newest")
+        assert len(groups) == 1
+        assert groups[0].canonical_hash == "h2"  # newer
+        assert set(groups[0].hashes) == {"h1", "h2"}
+
+    def test_three_way_cluster(self):
+        v = [1.0, 0.0, 0.0]
+        memories = [
+            _memory("a", "h1", created_at=1000.0),
+            _memory("b", "h2", created_at=2000.0),
+            _memory("c", "h3", created_at=3000.0),
+        ]
+        embeddings = [v, v, v]
+        groups = build_duplicate_groups(memories, embeddings, similarity_threshold=0.95, strategy="keep_newest")
+        assert len(groups) == 1
+        assert groups[0].canonical_hash == "h3"
+        assert len(groups[0].hashes) == 3
+
+    def test_groups_sorted_by_similarity(self):
+        # Two separate pairs: cluster A (dimensions 0,1), cluster B (dimensions 2,3)
+        # Each pair is identical within the cluster; zero overlap between clusters.
+        memories = [
+            _memory("a", "h1"),
+            _memory("b", "h2"),
+            _memory("c", "h3"),
+            _memory("d", "h4"),
+        ]
+        v_a = [1.0, 0.0, 0.0, 0.0]
+        v_b = [0.0, 0.0, 1.0, 0.0]
+        embeddings = [v_a, v_a, v_b, v_b]
+        groups = build_duplicate_groups(memories, embeddings, similarity_threshold=0.9)
+        assert len(groups) == 2
+        assert groups[0].max_similarity >= groups[1].max_similarity
+
+    def test_to_dict_serializable(self):
+        v = [1.0, 0.0]
+        memories = [_memory("a", "h1", created_at=1000.0), _memory("b", "h2", created_at=2000.0)]
+        embeddings = [v, v]
+        groups = build_duplicate_groups(memories, embeddings, similarity_threshold=0.9)
+        d = groups[0].to_dict()
+        assert "hashes" in d
+        assert "canonical_hash" in d
+        assert "max_similarity" in d
+        assert "size" in d
+        assert isinstance(d["size"], int)


### PR DESCRIPTION
## Summary
- Adds deduplication engine using embedding cosine similarity + optional fuzzy text matching
- Union-Find groups transitive duplicates into clusters (A≈B, B≈C → {A,B,C})
- Three canonical selection strategies: keep_newest, keep_oldest, keep_most_accessed
- merge_duplicates uses existing supersede_memory pipeline (audit trail preserved)
- Two MCP tools: find_duplicates (scan) and merge_duplicates (with dry_run support)

## Expert Panel
- Code Craftsman: PASS — Well-structured utility with comprehensive tests (35 new)
- PR Reviewer: PASS — All storage method calls verified, reuses supersede pipeline
- Red Team: PASS — O(n²) bounded by limit, supersede-not-delete preserves audit trail
- Security: SKIP

Verdict: MERGE

## Test plan
- [x] 692 unit tests pass (35 new deduplication tests)
- [x] Ruff lint clean
- [x] Ruff format clean
- [x] Clean rebase on main (7545f19)