### PR TITLE
fix: convert stale-session 400 to spec-compliant 404

### DIFF
--- a/src/mcp_memory_service/unified_server.py
+++ b/src/mcp_memory_service/unified_server.py
@@ -30,10 +30,96 @@ import asyncio
 import logging
 import signal
 import sys
+from http import HTTPStatus
+
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from .shared_storage import close_shared_storage, get_shared_storage
 
 logger = logging.getLogger(__name__)
+
+# Header name (bytes, as ASGI transmits headers)
+_MCP_SESSION_ID = b"mcp-session-id"
+_STALE_SESSION_BODY = b"No valid session ID"
+
+
+class StaleSessionMiddleware:
+    """Convert stale-session 400 errors to spec-compliant 404.
+
+    The MCP SDK's StreamableHTTPSessionManager returns 400 when a client sends
+    a session ID the server doesn't recognise (e.g. after a pod restart).  Per
+    the MCP spec, expired/unknown sessions should return 404, which signals
+    clients to discard the stale session and re-initialise.
+
+    This ASGI middleware intercepts the response and rewrites the status code
+    when the specific stale-session error is detected.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Fast path: no session header → nothing to fix
+        has_session = any(k == _MCP_SESSION_ID for k, _ in scope.get("headers", []))
+        if not has_session:
+            await self.app(scope, receive, send)
+            return
+
+        # Buffer the response start so we can rewrite if needed
+        captured_start: dict | None = None
+        is_400 = False
+
+        async def send_wrapper(message: dict) -> None:
+            nonlocal captured_start, is_400
+
+            if message["type"] == "http.response.start":
+                if message.get("status") == HTTPStatus.BAD_REQUEST:
+                    # Hold the start message until we see the body
+                    captured_start = message
+                    is_400 = True
+                    return
+                await send(message)
+                return
+
+            if message["type"] == "http.response.body":
+                if is_400 and captured_start is not None:
+                    if message.get("more_body", False):
+                        # Streamed response — not our single-chunk target.
+                        # Release the buffered start and forward all chunks.
+                        await send(captured_start)
+                        await send(message)
+                        captured_start = None
+                        is_400 = False
+                    else:
+                        # Final (or only) body chunk — safe to inspect.
+                        body = message.get("body", b"")
+                        if _STALE_SESSION_BODY in body:
+                            logger.warning("Rewriting stale-session 400 → 404 for client re-initialisation")
+                            captured_start["status"] = HTTPStatus.NOT_FOUND
+                            await send(captured_start)
+                            await send(
+                                {
+                                    "type": "http.response.body",
+                                    "body": b"Not Found: Session expired, please re-initialize",
+                                }
+                            )
+                        else:
+                            # Not the error we're looking for — pass through
+                            await send(captured_start)
+                            await send(message)
+                        captured_start = None
+                        is_400 = False
+                else:
+                    await send(message)
+                return
+
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
 
 
 class UnifiedServer:
@@ -108,6 +194,8 @@ class UnifiedServer:
         try:
             import os
 
+            from starlette.middleware import Middleware
+
             from mcp_memory_service.mcp_server import mcp
 
             # Get port and host from environment
@@ -121,7 +209,13 @@ class UnifiedServer:
 
             # FastMCP v2.0 async API
             if transport == "http":
-                await mcp.run_async(transport="http", host=host, port=port, uvicorn_config={"ws": "none"})
+                await mcp.run_async(
+                    transport="http",
+                    host=host,
+                    port=port,
+                    uvicorn_config={"ws": "none"},
+                    middleware=[Middleware(StaleSessionMiddleware)],
+                )
             else:
                 await mcp.run_async(transport="stdio")
         except Exception as e:

--- a/tests/unit/test_stale_session_middleware.py
+++ b/tests/unit/test_stale_session_middleware.py
@@ -1,0 +1,155 @@
+"""Tests for StaleSessionMiddleware — converts stale-session 400 → 404."""
+
+from http import HTTPStatus
+
+import pytest
+
+from mcp_memory_service.unified_server import StaleSessionMiddleware
+
+
+def _make_scope(headers: list[tuple[bytes, bytes]] | None = None) -> dict:
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": headers or [],
+    }
+
+
+class _Captured:
+    """Collects ASGI messages sent by the middleware."""
+
+    def __init__(self) -> None:
+        self.messages: list[dict] = []
+
+    async def __call__(self, message: dict) -> None:
+        self.messages.append(message)
+
+
+def _fake_app(status: int, body: bytes):
+    """Return a minimal ASGI app that sends a fixed response."""
+
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+
+    return app
+
+
+def _fake_streamed_app(status: int, chunks: list[bytes]):
+    """Return an ASGI app that sends the body in multiple chunks with more_body."""
+
+    async def app(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        for i, chunk in enumerate(chunks):
+            is_last = i == len(chunks) - 1
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": chunk,
+                    "more_body": not is_last,
+                }
+            )
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_stale_session_400_rewritten_to_404():
+    """A 400 with the stale-session message should become 404."""
+    inner = _fake_app(400, b"Bad Request: No valid session ID provided")
+    mw = StaleSessionMiddleware(inner)
+
+    scope = _make_scope(headers=[(b"mcp-session-id", b"dead-session-abc")])
+    captured = _Captured()
+    await mw(scope, None, captured)
+
+    assert len(captured.messages) == 2
+    assert captured.messages[0]["status"] == HTTPStatus.NOT_FOUND
+    assert b"Session expired" in captured.messages[1]["body"]
+
+
+@pytest.mark.asyncio
+async def test_non_session_400_passes_through():
+    """A 400 for some other reason should NOT be rewritten."""
+    inner = _fake_app(400, b"Bad Request: Invalid JSON")
+    mw = StaleSessionMiddleware(inner)
+
+    scope = _make_scope(headers=[(b"mcp-session-id", b"some-session")])
+    captured = _Captured()
+    await mw(scope, None, captured)
+
+    assert len(captured.messages) == 2
+    assert captured.messages[0]["status"] == HTTPStatus.BAD_REQUEST
+    assert b"Invalid JSON" in captured.messages[1]["body"]
+
+
+@pytest.mark.asyncio
+async def test_200_passes_through_unchanged():
+    """Successful responses are never touched."""
+    inner = _fake_app(200, b'{"result": "ok"}')
+    mw = StaleSessionMiddleware(inner)
+
+    scope = _make_scope(headers=[(b"mcp-session-id", b"valid-session")])
+    captured = _Captured()
+    await mw(scope, None, captured)
+
+    assert len(captured.messages) == 2
+    assert captured.messages[0]["status"] == 200
+    assert captured.messages[1]["body"] == b'{"result": "ok"}'
+
+
+@pytest.mark.asyncio
+async def test_no_session_header_fast_path():
+    """Requests without mcp-session-id skip the middleware entirely."""
+    inner = _fake_app(400, b"Bad Request: No valid session ID provided")
+    mw = StaleSessionMiddleware(inner)
+
+    scope = _make_scope(headers=[])
+    captured = _Captured()
+    await mw(scope, None, captured)
+
+    # Even though the body matches, no rewrite — fast path skipped it
+    assert captured.messages[0]["status"] == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_non_http_scope_passes_through():
+    """Non-HTTP scopes (websocket, lifespan) are ignored."""
+    inner = _fake_app(400, b"Bad Request: No valid session ID provided")
+    mw = StaleSessionMiddleware(inner)
+
+    scope = {"type": "lifespan"}
+    captured = _Captured()
+    await mw(scope, None, captured)
+
+    # The inner app was called, messages pass through
+    assert captured.messages[0]["status"] == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_streamed_400_passes_through():
+    """A streamed 400 (more_body=True) is never our target — forward unchanged."""
+    inner = _fake_streamed_app(400, [b"Bad Request: ", b"No valid session ID provided"])
+    mw = StaleSessionMiddleware(inner)
+
+    scope = _make_scope(headers=[(b"mcp-session-id", b"stale-session")])
+    captured = _Captured()
+    await mw(scope, None, captured)
+
+    # Start message + 2 body chunks all forwarded, status untouched
+    assert captured.messages[0]["status"] == HTTPStatus.BAD_REQUEST
+    bodies = [m["body"] for m in captured.messages if m["type"] == "http.response.body"]
+    assert bodies == [b"Bad Request: ", b"No valid session ID provided"]


### PR DESCRIPTION
## Summary

- Adds `StaleSessionMiddleware` (ASGI) that intercepts the MCP SDK's 400 "No valid session ID" response and rewrites it to 404 "Session expired"
- Per the MCP spec, 404 signals clients to discard stale sessions and re-initialise — the SDK's 400 gives no recovery path
- Injected via FastMCP's `middleware` kwarg on the streamable HTTP transport

## Context

Every pod restart wipes the SDK's in-memory session store (`StreamableHTTPSessionManager._server_instances`). Clients holding old session IDs get a hard 400 with no way to recover except manual `/mcp` reconnect.

The MCP spec says:
> If the server returns HTTP 404 (Not Found), the client MUST start a new session by sending a new InitializeRequest without the Mcp-Session-Id header.

This is a server-side workaround for `mcp` SDK v1.21.2 (`streamable_http_manager.py:273-279`).

## Test plan

- [x] Unit tests: 5 cases covering rewrite, passthrough, fast paths, non-HTTP scopes
- [x] Full unit suite: 671 passed, 0 failed
- [x] Lint + format gates pass
- [ ] Deploy to k3s, restart pod, verify client auto-reconnects on 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improve handling of stale session responses: requests with an MCP session header that previously returned a 400 for expired sessions now return a 404 with a clear "Session expired" body.

* **Tests**
  * Added comprehensive tests covering rewritten responses, pass-through cases, non-HTTP scopes, and streamed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->