### PR TITLE
feat: golden-sample integration tests for full search pipeline

### DIFF
--- a/docs/plans/2026-02-26-golden-sample-integration-tests-design.md
+++ b/docs/plans/2026-02-26-golden-sample-integration-tests-design.md
@@ -1,0 +1,147 @@
+# Golden-Sample Integration Tests
+
+## Problem
+
+860 tests exist but none exercise the full search pipeline with all features enabled.
+Every feature (Hebbian, semantic tags, intent inference, temporal decay, salience,
+spaced repetition, spreading activation) is tested in isolation. The `test_fanout_e2e.py`
+explicitly disables all boost stages. We cannot prove these features compose correctly.
+
+## Design
+
+### Test Data: Project Gutenberg Golden Samples
+
+41 public domain passages from diverse sources (literature, philosophy, science,
+political theory, history). Each passage is 200-800 characters with clear thematic
+signal. Passages are grouped into **thematic clusters** where 2-3 passages share a
+theme across different sources, enabling cross-source semantic retrieval tests.
+
+Fixture file: `@tests/integration/fixtures/golden_samples.json`
+
+Structure — a top-level JSON array of memory objects:
+```json
+[
+  {
+    "id": "gutenberg_1232_1",
+    "content": "passage text",
+    "source": "The Prince by Machiavelli",
+    "themes": ["leadership", "power", "politics"],
+    "tags": ["philosophy", "politics", "leadership"],
+    "memory_type": "reference"
+  },
+  ...
+]
+```
+
+### Test File: `@tests/integration/test_search_pipeline.py`
+
+Single file, 7 test classes, ~30 test methods. All use real Qdrant `:memory:` storage
+with real embeddings. No mocks for storage or embeddings.
+
+### Test Classes
+
+#### 1. `TestBaselineSemantic` — Pure vector search, all boosts disabled
+- Store all golden samples
+- Query with thematic queries ("nature of justice", "art of war", "scientific method")
+- Assert: correct thematic cluster members appear in top-K
+- Assert: cosine similarity scores are in expected range (0.3-0.8)
+- This is the **control group** — all other tests compare against this baseline
+
+#### 2. `TestTagMatching` — Exact + semantic tag search
+- Query with tag-matching keywords
+- Assert: exact tag matches rank higher than pure semantic matches
+- Assert: semantic tag matching finds related tags (e.g., "governance" finds "politics")
+- Compare RRF-fused results against baseline — tag signal should improve relevant rankings
+
+#### 3. `TestTemporalDecay` — Time-based relevance degradation
+- Store memories with controlled `created_at` timestamps (1 day, 7 days, 30 days, 90 days ago)
+- Enable temporal decay (`temporal_decay_lambda=0.01`)
+- Assert: recent memories score higher than old ones for equal semantic similarity
+- Assert: decay factor is mathematically correct: `base + exp(-lambda * days) * (1 - base)`
+
+#### 4. `TestSalienceBoost` — Emotional/importance scoring
+- Store memories with varying `metadata.importance` (0.0, 0.5, 1.0)
+- Enable salience boost
+- Assert: high-importance memories rank above equivalent low-importance ones
+- Assert: boost magnitude matches config (`boost_weight * salience_score`)
+
+#### 5. `TestQueryIntentFanout` — Multi-concept query decomposition
+- Query with multi-concept queries ("leadership philosophy and military strategy")
+- Assert: results span multiple thematic clusters (not just the best single-vector match)
+- Assert: memories matching multiple concepts rank higher (RRF multi-list weighting)
+
+#### 6. `TestFullPipeline` — All features enabled simultaneously
+- Default production config (all features on, FalkorDB off since no graph in test)
+- Run the same queries as TestBaselineSemantic
+- Assert: results are at least as good (Hit Rate >= baseline)
+- Assert: no score exceeds 1.0 (cap works)
+- Assert: min_similarity filter works (no results below threshold)
+- Assert: pagination works correctly (page 1 + page 2 cover full result set, no overlaps)
+
+#### 7. `TestPerformance` — Latency benchmarks
+- Store all golden samples
+- Time 100 sequential queries
+- Assert: p50 < 100ms, p95 < 300ms, p99 < 500ms (in-memory Qdrant)
+- Assert: no query takes > 1s
+- Store timing distribution for regression tracking
+
+### Fixture Architecture
+
+```python
+@pytest.fixture(scope="module")
+async def seeded_storage():
+    """Qdrant :memory: storage seeded with all golden samples."""
+    storage = QdrantStorage(
+        storage_path=":memory:",
+        embedding_model="all-MiniLM-L6-v2",  # fast, deterministic
+        collection_name=f"golden_{uuid.uuid4().hex[:8]}",
+    )
+    await storage.initialize()
+    # Seed from golden_samples.json
+    ...
+    yield storage
+    await storage.close()
+
+@pytest.fixture(scope="module")
+async def seeded_service(seeded_storage):
+    """MemoryService wrapping seeded storage with all defaults."""
+    return MemoryService(seeded_storage)
+```
+
+Module-scoped to avoid re-seeding per test (embedding generation is expensive).
+
+### Assertion Strategy
+
+**Ranking assertions** use relative ordering, not absolute positions:
+```python
+def assert_ranks_above(results, higher_hash, lower_hash):
+    """Assert higher_hash appears before lower_hash in results."""
+```
+
+**Score assertions** use tolerance bands, not exact values:
+```python
+def assert_score_in_range(result, min_score, max_score):
+```
+
+**Hit assertions** check set membership in top-K:
+```python
+def assert_any_hit(results, expected_hashes, k=10):
+    """At least one expected hash in top-K results."""
+```
+
+### What This Does NOT Test
+
+- FalkorDB graph features (Hebbian, spreading activation) — requires graph database
+- Encoding context boost — requires matching encoding contexts at store and retrieve time
+- Spaced repetition — requires simulated access patterns over time
+- Superseded memory filter — requires supersession relationships
+
+These are documented as out-of-scope for Phase 1. Phase 2 can add a FalkorDB
+integration test with `testcontainers` if needed.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `@tests/integration/fixtures/golden_samples.json` | Gutenberg passages |
+| `@tests/integration/test_search_pipeline.py` | Integration test suite |

--- a/tests/integration/fixtures/golden_samples.json
+++ b/tests/integration/fixtures/golden_samples.json
@@ -1,0 +1,330 @@
+[
+  {
+    "id": "gutenberg_1342_1",
+    "content": "It is a truth universally acknowledged, that a single man in possession of a good fortune must be in want of a wife. However little known the feelings or views of such a man may be on his first entering a neighbourhood, this truth is so well fixed in the minds of the surrounding families, that he is considered as the rightful property of some one or other of their daughters.",
+    "source": "Pride and Prejudice by Jane Austen",
+    "themes": ["marriage", "social class", "wealth", "first impressions"],
+    "tags": ["fiction", "social-commentary", "19th-century", "british-literature"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_2701_1",
+    "content": "Call me Ishmael. Some years ago -- never mind how long precisely -- having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation. Whenever I find myself growing grim about the mouth; whenever it is a damp, drizzly November in my soul; whenever I find myself involuntarily pausing before coffin warehouses, and bringing up the rear of every funeral I meet -- then, I account it high time to get to sea as soon as I can.",
+    "source": "Moby Dick by Herman Melville",
+    "themes": ["the sea", "melancholy", "adventure", "human restlessness"],
+    "tags": ["fiction", "american-literature", "19th-century", "adventure"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_2701_2",
+    "content": "There now is your insular city of the Manhattoes, belted round by wharves as Indian isles by coral reefs -- commerce surrounds it with her surf. Right and left, the streets take you waterward. Its extreme downtown is the battery, where that noble mole is washed by waves, and cooled by breezes, which a few hours previous were out of sight of land. Look at the crowds of water-gazers there.",
+    "source": "Moby Dick by Herman Melville",
+    "themes": ["the sea", "commerce", "urban life", "nature"],
+    "tags": ["fiction", "american-literature", "19th-century", "nature"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_1232_1",
+    "content": "Every prince ought to desire to be considered clement and not cruel. Nevertheless he ought to take care not to misuse this clemency. Cesare Borgia was considered cruel; notwithstanding, his cruelty reconciled the Romagna, unified it, and restored it to peace and loyalty. And if this be rightly considered, he will be seen to have been much more merciful than the Florentine people, who, to avoid a reputation for cruelty, permitted Pistoia to be destroyed. Therefore a prince, so long as he keeps his subjects united and loyal, ought not to mind the reproach of cruelty; because with a few examples he will be more merciful than those who, through too much mercy, allow disorders to arise, from which follow murders or robberies.",
+    "source": "The Prince by Niccolo Machiavelli",
+    "themes": ["leadership", "cruelty", "mercy", "political power", "statecraft"],
+    "tags": ["political-theory", "philosophy", "leadership", "renaissance"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_1232_2",
+    "content": "Upon this a question arises: whether it be better to be loved than feared or feared than loved? It may be answered that one should wish to be both, but, because it is difficult to unite them in one person, it is much safer to be feared than loved, when, of the two, either must be dispensed with. Because this is to be asserted in general of men, that they are ungrateful, fickle, false, cowardly, covetous, and as long as you succeed they are yours entirely.",
+    "source": "The Prince by Niccolo Machiavelli",
+    "themes": ["leadership", "power", "human nature", "fear", "love"],
+    "tags": ["political-theory", "philosophy", "leadership", "renaissance"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_1232_3",
+    "content": "The wish to acquire is in truth very natural and common, and men always do so when they can, and for this they will be praised not blamed; but when they cannot do so, yet wish to do so by any means, then there is folly and blame. Therefore, if France could have attacked Naples with her own forces she ought to have done so; if she could not, then she ought not to have divided it.",
+    "source": "The Prince by Niccolo Machiavelli",
+    "themes": ["ambition", "statecraft", "military strategy", "political wisdom"],
+    "tags": ["political-theory", "philosophy", "strategy", "renaissance"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_2680_1",
+    "content": "Remember how long thou hast already put off these things, and how often a certain day and hour as it were, having been set unto thee by the gods, thou hast neglected it. It is high time for thee to understand the true nature both of the world, whereof thou art a part; and of that Lord and Governor of the world, from whom, as a channel from the spring, thou thyself didst flow: and that there is but a certain limit of time appointed unto thee, which if thou shalt not make use of to calm and allay the many distempers of thy soul, it will pass away and thou with it, and never after return.",
+    "source": "Meditations by Marcus Aurelius",
+    "themes": ["mortality", "self-discipline", "time", "stoic philosophy", "urgency"],
+    "tags": ["philosophy", "stoicism", "self-improvement", "ancient-rome"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_2680_2",
+    "content": "Let it be thy earnest and incessant care as a Roman and a man to perform whatsoever it is that thou art about, with true and unfeigned gravity, natural affection, freedom and justice: and as for all other cares, and imaginations, how thou mayest ease thy mind of them. Which thou shalt do; if thou shalt go about every action as thy last action, free from all vanity, all passionate and wilful aberration from reason, and from all hypocrisy, and self-love, and dislike of those things, which by the fates or appointment of God have happened unto thee.",
+    "source": "Meditations by Marcus Aurelius",
+    "themes": ["duty", "stoic philosophy", "virtue", "mindfulness", "reason"],
+    "tags": ["philosophy", "stoicism", "self-improvement", "ancient-rome"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_2680_3",
+    "content": "Do, soul, do; abuse and contemn thyself; yet a while and the time for thee to respect thyself, will be at an end. Every man's happiness depends from himself, but behold thy life is almost at an end, whiles affording thyself no respect, thou dost make thy happiness to consist in the souls, and conceits of other men.",
+    "source": "Meditations by Marcus Aurelius",
+    "themes": ["self-respect", "happiness", "mortality", "independence of mind"],
+    "tags": ["philosophy", "stoicism", "self-improvement", "ancient-rome"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_2680_4",
+    "content": "Why should any of these things that happen externally, so much distract thee? Give thyself leisure to learn some good thing, and cease roving and wandering to and fro. Thou must also take heed of another kind of wandering, for they are idle in their actions, who toil and labour in this life, and have no certain scope to which to direct all their motions, and desires.",
+    "source": "Meditations by Marcus Aurelius",
+    "themes": ["focus", "purpose", "self-discipline", "distraction"],
+    "tags": ["philosophy", "stoicism", "self-improvement", "ancient-rome"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_1497_1",
+    "content": "The figure of the cave in Book VII is a recapitulation of the divisions of knowledge in Book VI. The composite animal in Book IX is an allegory of the parts of the soul. The noble captain and the ship and the true pilot in Book VI are a figure of the relation of the people to the philosophers in the State which has been described.",
+    "source": "The Republic by Plato",
+    "themes": ["knowledge", "allegory", "philosophy", "the soul", "governance"],
+    "tags": ["philosophy", "ancient-greece", "political-theory", "epistemology"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_1497_2",
+    "content": "To him, as to other great teachers both philosophical and religious, when they looked upward, the world seemed to be the embodiment of error and evil. The common sense of mankind has revolted against this view.",
+    "source": "The Republic by Plato",
+    "themes": ["idealism", "philosophy", "good and evil", "perception"],
+    "tags": ["philosophy", "ancient-greece", "epistemology", "metaphysics"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_84_1",
+    "content": "What had been the study and desire of the wisest men since the creation of the world was now within my grasp. Not that, like a magic scene, it all opened upon me at once: the information I had obtained was of a nature rather to direct my endeavours so soon as I should point them towards the object of my search than to exhibit that object already accomplished. I was like the Arabian who had been buried with the dead and found a passage to life, aided only by one glimmering and seemingly ineffectual light.",
+    "source": "Frankenstein by Mary Shelley",
+    "themes": ["scientific discovery", "ambition", "knowledge", "creation"],
+    "tags": ["fiction", "science-fiction", "gothic", "19th-century"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_84_2",
+    "content": "Learn from me, if not by my precepts, at least by my example, how dangerous is the acquirement of knowledge and how much happier that man is who believes his native town to be the world, than he who aspires to become greater than his nature will allow.",
+    "source": "Frankenstein by Mary Shelley",
+    "themes": ["hubris", "knowledge", "consequences of science", "human limits"],
+    "tags": ["fiction", "science-fiction", "gothic", "19th-century", "ethics"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_84_3",
+    "content": "When I found so astonishing a power placed within my hands, I hesitated a long time concerning the manner in which I should employ it. Although I possessed the capacity of bestowing animation, yet to prepare a frame for the reception of it, with all its intricacies of fibres, muscles, and veins, still remained a work of inconceivable difficulty and labour. I doubted at first whether I should attempt the creation of a being like myself, or one of simpler organization; but my imagination was too much exalted by my first success to permit me to doubt of my ability to give life to an animal as complex and wonderful as man.",
+    "source": "Frankenstein by Mary Shelley",
+    "themes": ["creation", "power", "ambition", "playing God", "science"],
+    "tags": ["fiction", "science-fiction", "gothic", "19th-century", "ethics"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_1661_1",
+    "content": "He was, I take it, the most perfect reasoning and observing machine that the world has seen, but as a lover he would have placed himself in a false position. He never spoke of the softer passions, save with a gibe and a sneer. They were admirable things for the observer -- excellent for drawing the veil from men's motives and actions. But for the trained reasoner to admit such intrusions into his own delicate and finely adjusted temperament was to introduce a distracting factor which might throw a doubt upon all his mental results. Grit in a sensitive instrument, or a crack in one of his own high-power lenses, would not be more disturbing than a strong emotion in a nature such as his.",
+    "source": "The Adventures of Sherlock Holmes by Arthur Conan Doyle",
+    "themes": ["reason", "logic", "emotion", "observation", "the scientific mind"],
+    "tags": ["fiction", "detective", "19th-century", "british-literature"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_1661_2",
+    "content": "You see, but you do not observe. The distinction is clear. For example, you have frequently seen the steps which lead up from the hall to this room. How often? Well, some hundreds of times. Then how many are there? How many? I don't know. Quite so! You have not observed. And yet you have seen. That is just my point. Now, I know that there are seventeen steps, because I have both seen and observed.",
+    "source": "The Adventures of Sherlock Holmes by Arthur Conan Doyle",
+    "themes": ["observation", "perception", "attention to detail", "deduction"],
+    "tags": ["fiction", "detective", "19th-century", "logic"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_1661_3",
+    "content": "It is a capital mistake to theorise before one has data. Insensibly one begins to twist facts to suit theories, instead of theories to suit facts. But the note itself. What do you deduce from it? I carefully examined the writing, and the paper upon which it was written. The man who wrote it was presumably well to do. Such paper could not be bought under half a crown a packet. It is peculiarly strong and stiff.",
+    "source": "The Adventures of Sherlock Holmes by Arthur Conan Doyle",
+    "themes": ["scientific method", "logic", "reasoning", "evidence"],
+    "tags": ["fiction", "detective", "19th-century", "logic", "epistemology"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_98_1",
+    "content": "It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair, we had everything before us, we had nothing before us, we were all going direct to Heaven, we were all going direct the other way -- in short, the period was so far like the present period, that some of its noisiest authorities insisted on its being received, for good or for evil, in the superlative degree of comparison only.",
+    "source": "A Tale of Two Cities by Charles Dickens",
+    "themes": ["revolution", "duality", "social upheaval", "history", "hope and despair"],
+    "tags": ["fiction", "historical", "19th-century", "british-literature"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_36_1",
+    "content": "With infinite complacency men went to and fro over this globe about their little affairs, serene in their assurance of their empire over matter. It is possible that the infusoria under the microscope do the same. No one gave a thought to the older worlds of space as sources of human danger, or thought of them only to dismiss the idea of life upon them as impossible or improbable.",
+    "source": "The War of the Worlds by H.G. Wells",
+    "themes": ["alien life", "human arrogance", "cosmic insignificance", "technology"],
+    "tags": ["fiction", "science-fiction", "19th-century", "british-literature"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_36_2",
+    "content": "Yet across the gulf of space, minds that are to our minds as ours are to those of the beasts that perish, intellects vast and cool and unsympathetic, regarded this earth with envious eyes, and slowly and surely drew their plans against us. And early in the twentieth century came the great disillusionment.",
+    "source": "The War of the Worlds by H.G. Wells",
+    "themes": ["alien invasion", "superior intelligence", "existential threat", "hubris"],
+    "tags": ["fiction", "science-fiction", "19th-century", "british-literature"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_35_1",
+    "content": "Clearly, any real body must have extension in four directions: it must have Length, Breadth, Thickness, and -- Duration. But through a natural infirmity of the flesh, which I will explain to you in a moment, we incline to overlook this fact. There are really four dimensions, three which we call the three planes of Space, and a fourth, Time. There is, however, a tendency to draw an unreal distinction between the former three dimensions and the latter, because it happens that our consciousness moves intermittently in one direction along the latter from the beginning to the end of our lives.",
+    "source": "The Time Machine by H.G. Wells",
+    "themes": ["time travel", "dimensions", "physics", "space-time", "consciousness"],
+    "tags": ["fiction", "science-fiction", "19th-century", "physics"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_219_1",
+    "content": "The sea-reach of the Thames stretched before us like the beginning of an interminable waterway. In the offing the sea and the sky were welded together without a joint, and in the luminous space the tanned sails of the barges drifting up with the tide seemed to stand still in red clusters of canvas sharply peaked, with gleams of varnished sprits. A haze rested on the low shores that ran out to sea in vanishing flatness. The air was dark above Gravesend, and farther back still seemed condensed into a mournful gloom, brooding motionless over the biggest, and the greatest, town on earth.",
+    "source": "Heart of Darkness by Joseph Conrad",
+    "themes": ["the sea", "darkness", "empire", "foreboding", "nature"],
+    "tags": ["fiction", "19th-century", "british-literature", "colonialism"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_219_2",
+    "content": "The conquest of the earth, which mostly means the taking it away from those who have a different complexion or slightly flatter noses than ourselves, is not a pretty thing when you look into it too much. What redeems it is the idea only. An idea at the back of it; not a sentimental pretence but an idea; and an unselfish belief in the idea -- something you can set up, and bow down before, and offer a sacrifice to.",
+    "source": "Heart of Darkness by Joseph Conrad",
+    "themes": ["colonialism", "imperialism", "ideology", "conquest", "moral ambiguity"],
+    "tags": ["fiction", "19th-century", "british-literature", "colonialism", "ethics"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_219_3",
+    "content": "And it has a fascination, too, that goes to work upon him. The fascination of the abomination -- you know, imagine the growing regrets, the longing to escape, the powerless disgust, the surrender, the hate.",
+    "source": "Heart of Darkness by Joseph Conrad",
+    "themes": ["darkness", "temptation", "moral corruption", "the human condition"],
+    "tags": ["fiction", "19th-century", "british-literature", "psychology"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_174_1",
+    "content": "The artist is the creator of beautiful things. To reveal art and conceal the artist is art's aim. The critic is he who can translate into another manner or a new material his impression of beautiful things. The highest as the lowest form of criticism is a mode of autobiography. Those who find ugly meanings in beautiful things are corrupt without being charming. This is a fault. Those who find beautiful meanings in beautiful things are the cultivated. For these there is hope. They are the elect to whom beautiful things mean only beauty.",
+    "source": "The Picture of Dorian Gray by Oscar Wilde",
+    "themes": ["art", "beauty", "criticism", "aestheticism"],
+    "tags": ["fiction", "19th-century", "british-literature", "aesthetics"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_174_2",
+    "content": "There is no such thing as a moral or an immoral book. Books are well written, or badly written. That is all. No artist desires to prove anything. Even things that are true can be proved. No artist has ethical sympathies. An ethical sympathy in an artist is an unpardonable mannerism of style. No artist is ever morbid. The artist can express everything. Thought and language are to the artist instruments of an art. Vice and virtue are to the artist materials for an art.",
+    "source": "The Picture of Dorian Gray by Oscar Wilde",
+    "themes": ["art", "morality", "aestheticism", "literary criticism"],
+    "tags": ["fiction", "19th-century", "british-literature", "aesthetics", "ethics"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_174_3",
+    "content": "All art is at once surface and symbol. Those who go beneath the surface do so at their peril. Those who read the symbol do so at their peril. It is the spectator, and not life, that art really mirrors. Diversity of opinion about a work of art shows that the work is new, complex, and vital. When critics disagree, the artist is in accord with himself. All art is quite useless.",
+    "source": "The Picture of Dorian Gray by Oscar Wilde",
+    "themes": ["art", "symbolism", "perception", "aestheticism"],
+    "tags": ["fiction", "19th-century", "british-literature", "aesthetics"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_11_1",
+    "content": "Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, 'and what is the use of a book,' thought Alice 'without pictures or conversations?' So she was considering in her own mind (as well as she could, for the hot day made her feel very sleepy and stupid), whether the pleasure of making a daisy-chain would be worth the trouble of getting up and picking the daisies, when suddenly a White Rabbit with pink eyes ran close by her.",
+    "source": "Alice's Adventures in Wonderland by Lewis Carroll",
+    "themes": ["curiosity", "boredom", "imagination", "childhood"],
+    "tags": ["fiction", "fantasy", "19th-century", "british-literature", "children"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_2009_1",
+    "content": "As many more individuals of each species are born than can possibly survive; and as, consequently, there is a frequently recurring struggle for existence, it follows that any being, if it vary however slightly in any manner profitable to itself, under the complex and sometimes varying conditions of life, will have a better chance of surviving, and thus be naturally selected. From the strong principle of inheritance, any selected variety will tend to propagate its new and modified form.",
+    "source": "On the Origin of Species by Charles Darwin",
+    "themes": ["natural selection", "evolution", "survival", "adaptation", "biology"],
+    "tags": ["science", "biology", "19th-century", "evolution"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_2009_2",
+    "content": "Natural selection almost inevitably causes much extinction of the less improved forms of life, and leads to what I have called divergence of character. In the next chapter I shall discuss the complex and little known laws of variation. In the five succeeding chapters, the most apparent and gravest difficulties in accepting the theory will be given: namely, first, the difficulties of transitions, or how a simple being or a simple organ can be changed and perfected into a highly developed being or into an elaborately constructed organ.",
+    "source": "On the Origin of Species by Charles Darwin",
+    "themes": ["natural selection", "extinction", "evolution", "biodiversity"],
+    "tags": ["science", "biology", "19th-century", "evolution"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_7370_1",
+    "content": "Though this be a state of liberty, yet it is not a state of licence: though man in that state have an uncontroulable liberty to dispose of his person or possessions, yet he has not liberty to destroy himself, or so much as any creature in his possession, but where some nobler use than its bare preservation calls for it. The state of nature has a law of nature to govern it, which obliges every one: and reason, which is that law, teaches all mankind, who will but consult it, that being all equal and independent, no one ought to harm another in his life, health, liberty, or possessions.",
+    "source": "Second Treatise of Government by John Locke",
+    "themes": ["natural rights", "liberty", "equality", "law of nature", "reason"],
+    "tags": ["political-theory", "philosophy", "17th-century", "enlightenment"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_7370_2",
+    "content": "For men being all the workmanship of one omnipotent, and infinitely wise maker; all the servants of one sovereign master, sent into the world by his order, and about his business; they are his property, whose workmanship they are, made to last during his, not one another's pleasure: and being furnished with like faculties, sharing all in one community of nature, there cannot be supposed any such subordination among us, that may authorize us to destroy one another, as if we were made for one another's uses.",
+    "source": "Second Treatise of Government by John Locke",
+    "themes": ["equality", "natural law", "human dignity", "divine creation"],
+    "tags": ["political-theory", "philosophy", "17th-century", "enlightenment"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_1952_1",
+    "content": "If a physician of high standing, and one's own husband, assures friends and relatives that there is really nothing the matter with one but temporary nervous depression -- a slight hysterical tendency -- what is one to do? My brother is also a physician, and also of high standing, and he says the same thing. So I take phosphates or phosphites -- whichever it is, and tonics, and journeys, and air, and exercise, and am absolutely forbidden to 'work' until I am well again. Personally, I disagree with their ideas. Personally, I believe that congenial work, with excitement and change, would do me good.",
+    "source": "The Yellow Wallpaper by Charlotte Perkins Gilman",
+    "themes": ["mental health", "medical authority", "gender", "oppression", "autonomy"],
+    "tags": ["fiction", "feminism", "19th-century", "american-literature", "psychology"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_1952_2",
+    "content": "One of those sprawling flamboyant patterns committing every artistic sin. It is dull enough to confuse the eye in following, pronounced enough to constantly irritate, and provoke study, and when you follow the lame, uncertain curves for a little distance they suddenly commit suicide -- plunge off at outrageous angles, destroy themselves in unheard-of contradictions. The color is repellant, almost revolting; a smouldering, unclean yellow, strangely faded by the slow-turning sunlight.",
+    "source": "The Yellow Wallpaper by Charlotte Perkins Gilman",
+    "themes": ["obsession", "perception", "confinement", "mental deterioration"],
+    "tags": ["fiction", "feminism", "19th-century", "american-literature", "psychology"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_1952_3",
+    "content": "This wallpaper has a kind of sub-pattern in a different shade, a particularly irritating one, for you can only see it in certain lights, and not clearly then. But in the places where it isn't faded, and where the sun is just so, I can see a strange, provoking, formless sort of figure, that seems to sulk about behind that silly and conspicuous front design.",
+    "source": "The Yellow Wallpaper by Charlotte Perkins Gilman",
+    "themes": ["hidden meaning", "perception", "madness", "symbolism"],
+    "tags": ["fiction", "feminism", "19th-century", "american-literature", "psychology"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_345_1",
+    "content": "Left Munich at 8:35 P.M., on 1st May, arriving at Vienna early next morning; should have arrived at 6:46, but train was an hour late. Buda-Pesth seems a wonderful place, from the glimpse which I got of it from the train and the little I could walk through the streets. I feared to go very far from the station, as we had arrived late and would start as near the correct time as possible. The impression I had was that we were leaving the West and entering the East; the most western of splendid bridges over the Danube, which is here of noble width and depth, took us among the traditions of Turkish rule.",
+    "source": "Dracula by Bram Stoker",
+    "themes": ["travel", "east and west", "journey", "foreboding"],
+    "tags": ["fiction", "gothic", "horror", "19th-century", "british-literature"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_1260_1",
+    "content": "There was no possibility of taking a walk that day. We had been wandering, indeed, in the leafless shrubbery an hour in the morning; but since dinner the cold winter wind had brought with it clouds so sombre, and a rain so penetrating, that further outdoor exercise was now out of the question. I was glad of it: I never liked long walks, especially on chilly afternoons: dreadful to me was the coming home in the raw twilight, with nipped fingers and toes, and a heart saddened by the chidings of Bessie, the nurse, and humbled by the consciousness of my physical inferiority to Eliza, John, and Georgiana Reed.",
+    "source": "Jane Eyre by Charlotte Bronte",
+    "themes": ["isolation", "childhood", "social hierarchy", "resilience"],
+    "tags": ["fiction", "19th-century", "british-literature", "feminism"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_16328_1",
+    "content": "Hrothgar, king of the Danes, builds a great mead-hall, or palace, in which he hopes to feast his liegemen and to give them presents. The joy of king and retainers is, however, of short duration. Grendel, the monster, is seized with hateful jealousy. He cannot brook the sounds of joyance that reach him down in his fen-dwelling near the hall. Oft and anon he goes to the joyous building, bent on direful mischief. Thane after thane is ruthlessly carried off and devoured, while no one is found strong enough and bold enough to cope with the monster. For twelve years he persecutes Hrothgar and his vassals.",
+    "source": "Beowulf (translated by J. Lesslie Hall)",
+    "themes": ["heroism", "monsters", "leadership", "duty", "Anglo-Saxon culture"],
+    "tags": ["poetry", "epic", "anglo-saxon", "medieval"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_16328_2",
+    "content": "Over sea, a day's voyage off, Beowulf, of the Geats, nephew of Higelac, king of the Geats, hears of Grendel's doings and of Hrothgar's misery. He resolves to crush the fell monster and relieve the aged king. With fourteen chosen companions, he sets sail for Dane-land. Reaching that country, he soon persuades Hrothgar of his ability to help him.",
+    "source": "Beowulf (translated by J. Lesslie Hall)",
+    "themes": ["heroism", "courage", "leadership", "duty", "adventure"],
+    "tags": ["poetry", "epic", "anglo-saxon", "medieval"],
+    "memory_type": "reference"
+  },
+  {
+    "id": "gutenberg_16328_3",
+    "content": "Grendel comes, the great march-stepper, bearing God's anger. He seizes and kills one of the sleeping warriors. Then he advances towards Beowulf. A fierce and desperate hand-to-hand struggle ensues. No arms are used, both combatants trusting to strength and hand-grip. Beowulf tears Grendel's shoulder from its socket, and the monster retreats to his den, howling and yelling with agony and fury. The wound is fatal.",
+    "source": "Beowulf (translated by J. Lesslie Hall)",
+    "themes": ["combat", "heroism", "good vs evil", "strength", "monsters"],
+    "tags": ["poetry", "epic", "anglo-saxon", "medieval"],
+    "memory_type": "reference"
+  }
+]

--- a/tests/integration/test_search_pipeline.py
+++ b/tests/integration/test_search_pipeline.py
@@ -1,0 +1,866 @@
+"""
+Golden-sample integration tests for the full search pipeline.
+
+Seeds 41 Project Gutenberg passages into Qdrant :memory: with real embeddings,
+then validates that every search pipeline stage (vector, RRF, tag, salience,
+temporal decay, fan-out, pagination, score cap) composes correctly.
+
+This is the single most important test file in the project: it proves the
+pipeline works end-to-end with real data and real models, not mocks.
+"""
+
+import json
+import math
+import os
+import time
+import uuid
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Force CPU to avoid CUDA issues in CI / dev
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+from mcp_memory_service.config import settings
+from mcp_memory_service.models.memory import Memory
+from mcp_memory_service.services.memory_service import MemoryService
+from mcp_memory_service.storage.qdrant_storage import QdrantStorage
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+
+def get_result_ids(results: list[dict], k: int = 10) -> list[str]:
+    """Extract content_hash IDs from top-K results."""
+    return [r["content_hash"] for r in results[:k]]
+
+
+def get_result_score(results: list[dict], content_hash: str) -> float | None:
+    """Get the similarity_score for a specific content_hash, or None if absent."""
+    for r in results:
+        if r["content_hash"] == content_hash:
+            return r["similarity_score"]
+    return None
+
+
+def assert_any_hit(results: list[dict], expected_ids: set[str], k: int = 10) -> None:
+    """At least one expected ID appears in top-K results."""
+    top_ids = set(get_result_ids(results, k))
+    overlap = top_ids & expected_ids
+    assert overlap, f"None of {expected_ids} found in top-{k} results. Got: {top_ids}"
+
+
+def assert_ranks_above(results: list[dict], higher_id: str, lower_id: str) -> None:
+    """Assert higher_id appears before lower_id in results."""
+    ids = [r["content_hash"] for r in results]
+    assert higher_id in ids, f"{higher_id} not found in results"
+    assert lower_id in ids, f"{lower_id} not found in results"
+    assert ids.index(higher_id) < ids.index(
+        lower_id
+    ), f"Expected {higher_id} (rank {ids.index(higher_id)}) above {lower_id} (rank {ids.index(lower_id)})"
+
+
+def get_themes(results: list[dict], k: int = 10) -> set[str]:
+    """Collect unique themes mentioned in result metadata (via golden sample tags)."""
+    tags: set[str] = set()
+    for r in results[:k]:
+        if r.get("tags"):
+            tags.update(r["tags"])
+    return tags
+
+
+# ---------------------------------------------------------------------------
+# Patch helpers
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _patched(*patches):
+    """Start all mock patches, yield, then stop them. Composable with `with`."""
+    with ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        yield
+
+
+def _disable_all_boosts():
+    """Return patch objects that disable every optional boost."""
+    return [
+        patch.object(settings.salience, "enabled", False),
+        patch.object(settings.spaced_repetition, "enabled", False),
+        patch.object(settings.encoding_context, "enabled", False),
+        patch.object(settings.hybrid_search, "temporal_decay_lambda", 0.0),
+        patch.object(settings.hybrid_search, "recency_decay", 0.0),
+        patch.object(settings.semantic_tag, "enabled", False),
+        patch.object(settings.intent, "enabled", False),
+    ]
+
+
+def _full_pipeline_patches():
+    """Patches for full pipeline matching production defaults where possible.
+
+    Uses recency_decay (not temporal_decay_lambda) because production defaults
+    to recency_decay=0.01 with temporal_decay_lambda=0.0.
+    """
+    return [
+        patch.object(settings.salience, "enabled", True),
+        patch.object(settings.salience, "boost_weight", 0.15),
+        patch.object(settings.spaced_repetition, "enabled", False),  # needs access history
+        patch.object(settings.encoding_context, "enabled", False),  # needs stored contexts
+        patch.object(settings.hybrid_search, "temporal_decay_lambda", 0.0),  # disabled (production default)
+        patch.object(settings.hybrid_search, "recency_decay", 0.01),  # production default
+        patch.object(settings.intent, "enabled", True),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _load_golden_samples() -> list[dict]:
+    """Load the 41-passage golden samples fixture."""
+    path = Path(__file__).parent / "fixtures" / "golden_samples.json"
+    with open(path) as f:
+        return json.load(f)
+
+
+GOLDEN_SAMPLES = _load_golden_samples()
+_SAMPLES_BY_ID = {s["id"]: s for s in GOLDEN_SAMPLES}
+
+# Thematic cluster ID sets (shared across test classes)
+MACHIAVELLI_IDS = {"gutenberg_1232_1", "gutenberg_1232_2", "gutenberg_1232_3"}
+AURELIUS_IDS = {"gutenberg_2680_1", "gutenberg_2680_2", "gutenberg_2680_3", "gutenberg_2680_4"}
+PLATO_IDS = {"gutenberg_1497_1", "gutenberg_1497_2"}
+BEOWULF_IDS = {"gutenberg_16328_1", "gutenberg_16328_2", "gutenberg_16328_3"}
+LOCKE_IDS = {"gutenberg_7370_1", "gutenberg_7370_2"}
+DARWIN_IDS = {"gutenberg_2009_1", "gutenberg_2009_2"}
+FRANKENSTEIN_IDS = {"gutenberg_84_1", "gutenberg_84_2", "gutenberg_84_3"}
+MELVILLE_IDS = {"gutenberg_2701_1", "gutenberg_2701_2"}
+CONRAD_IDS = {"gutenberg_219_1", "gutenberg_219_2", "gutenberg_219_3"}
+HOLMES_IDS = {"gutenberg_1661_1", "gutenberg_1661_2", "gutenberg_1661_3"}
+PHILOSOPHY_IDS = AURELIUS_IDS | PLATO_IDS
+GOVERNANCE_IDS = BEOWULF_IDS | LOCKE_IDS | PLATO_IDS | AURELIUS_IDS
+POLITICAL_IDS = MACHIAVELLI_IDS | PHILOSOPHY_IDS | PLATO_IDS
+SCIENCE_IDS = DARWIN_IDS | HOLMES_IDS | FRANKENSTEIN_IDS
+
+
+@pytest.fixture(scope="module")
+async def seeded_storage():
+    """Module-scoped Qdrant :memory: storage seeded with all 41 golden samples.
+
+    Uses all-MiniLM-L6-v2 (384-dim, fast) for reproducible embedding generation.
+    The collection name includes a random suffix to avoid cross-module collision.
+    """
+    storage = QdrantStorage(
+        storage_path=":memory:",
+        embedding_model="all-MiniLM-L6-v2",
+        collection_name=f"golden_{uuid.uuid4().hex[:8]}",
+    )
+    await storage.initialize()
+
+    for sample in GOLDEN_SAMPLES:
+        memory = Memory(
+            content=sample["content"],
+            content_hash=sample["id"],
+            tags=sample.get("tags", []),
+            memory_type=sample.get("memory_type", "reference"),
+        )
+        await storage.store(memory)
+
+    yield storage
+
+    await storage.close()
+
+
+@pytest.fixture(scope="module")
+async def service(seeded_storage):
+    """MemoryService backed by the module-scoped seeded storage (no graph)."""
+    return MemoryService(seeded_storage, graph_client=None)
+
+
+# ---------------------------------------------------------------------------
+# Class 1: Baseline Semantic (control group)
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineSemantic:
+    """Hybrid search with all boosts disabled. Establishes a quality baseline.
+
+    Uses default tags=None (hybrid RRF path with adaptive alpha), but disables
+    salience, temporal decay, intent fan-out, and all other optional boosts.
+    This mirrors production behavior with all optional features turned off.
+    """
+
+    @pytest.mark.asyncio
+    async def test_leadership_finds_machiavelli_and_political_theory(self, service):
+        """'leadership and power' should surface Machiavelli (explicit leadership content)
+        and at least one other political/governance source in top 10."""
+        with _patched(*_disable_all_boosts()):
+            result = await service.retrieve_memories(query="leadership and power", page_size=10)
+            memories = result["memories"]
+
+            assert_any_hit(memories, MACHIAVELLI_IDS, k=10)
+            assert_any_hit(memories, GOVERNANCE_IDS, k=10)
+
+    @pytest.mark.asyncio
+    async def test_scientific_discovery_finds_darwin_and_frankenstein(self, service):
+        """'scientific discovery' spans biology (Darwin) and fiction (Shelley)."""
+        with _patched(*_disable_all_boosts()):
+            result = await service.retrieve_memories(query="scientific discovery and natural world", page_size=10)
+            memories = result["memories"]
+
+            assert_any_hit(memories, DARWIN_IDS, k=10)
+            assert_any_hit(memories, FRANKENSTEIN_IDS, k=10)
+
+    @pytest.mark.asyncio
+    async def test_sea_and_adventure_finds_melville_and_conrad(self, service):
+        """'the sea and adventure' should retrieve both nautical authors."""
+        with _patched(*_disable_all_boosts()):
+            result = await service.retrieve_memories(query="the sea and adventure sailing", page_size=10)
+            memories = result["memories"]
+
+            assert_any_hit(memories, MELVILLE_IDS, k=10)
+            assert_any_hit(memories, CONRAD_IDS, k=10)
+
+    @pytest.mark.asyncio
+    async def test_scores_in_valid_range(self, service):
+        """Every returned score must be in [0.0, 1.0]."""
+        with _patched(*_disable_all_boosts()):
+            result = await service.retrieve_memories(query="philosophy and virtue", page_size=10)
+            for mem in result["memories"]:
+                score = mem["similarity_score"]
+                assert 0.0 <= score <= 1.0, f"Score {score} out of [0, 1] range"
+
+    @pytest.mark.asyncio
+    async def test_results_ordered_by_internal_rank(self, service):
+        """Results must be ordered by internal RRF rank (when hybrid) or
+        by cosine score (when vector-only). The displayed similarity_score
+        is the original cosine, so when RRF re-ranks, display scores may
+        not be strictly decreasing. We verify the internal rank is monotonic
+        by checking the hybrid_debug.rrf_score or, when in vector-only mode,
+        that displayed scores decrease."""
+        with _patched(*_disable_all_boosts()):
+            # Force vector-only by using a query with no matching existing tags
+            result = await service.retrieve_memories(query="xylophone concerto harmonica", page_size=10)
+            scores = [m["similarity_score"] for m in result["memories"]]
+            for i in range(len(scores) - 1):
+                assert (
+                    scores[i] >= scores[i + 1] - 1e-9
+                ), f"Vector-only: score at rank {i} ({scores[i]:.6f}) < score at rank {i + 1} ({scores[i + 1]:.6f})"
+
+
+# ---------------------------------------------------------------------------
+# Class 2: Tag Matching
+# ---------------------------------------------------------------------------
+
+
+class TestTagMatching:
+    """Validates that tag-based boosting via RRF actually changes rankings."""
+
+    @pytest.mark.asyncio
+    async def test_philosophy_tag_boosts_philosophy_results(self, service):
+        """Query containing 'philosophy' should promote philosophy-tagged memories
+        when hybrid search is active, vs pure vector fallback."""
+        with _patched(
+            patch.object(settings.salience, "enabled", False),
+            patch.object(settings.spaced_repetition, "enabled", False),
+            patch.object(settings.encoding_context, "enabled", False),
+            patch.object(settings.hybrid_search, "temporal_decay_lambda", 0.0),
+            patch.object(settings.hybrid_search, "recency_decay", 0.0),
+            patch.object(settings.intent, "enabled", False),
+        ):
+            result = await service.retrieve_memories(query="philosophy of the soul and virtue", page_size=10)
+            memories = result["memories"]
+
+            top_ids = set(get_result_ids(memories, k=10))
+            philosophy_hits = top_ids & PHILOSOPHY_IDS
+            assert (
+                len(philosophy_hits) >= 2
+            ), f"Expected >=2 philosophy-tagged results, got {len(philosophy_hits)}: {philosophy_hits}"
+
+    @pytest.mark.asyncio
+    async def test_no_matching_tags_falls_back_to_vector(self, service):
+        """A query with no tag matches should still return results via vector search.
+        The keyword 'xylophone' won't match any tags in the corpus."""
+        with _patched(*_disable_all_boosts()):
+            result = await service.retrieve_memories(query="xylophone music harmony instruments", page_size=5)
+            assert len(result["memories"]) > 0, "Expected vector-only fallback results"
+
+    @pytest.mark.asyncio
+    async def test_rrf_changes_ordering_vs_pure_vector(self, service):
+        """Hybrid search (RRF) should produce a different top-10 ordering than
+        pure vector search for a query that matches existing tags.
+
+        Pure vector is forced by setting alpha=1.0 (full vector weight),
+        which causes the code to short-circuit to _retrieve_vector_only."""
+        query = "political theory and leadership"
+
+        # Pure vector: alpha=1.0 forces vector-only path
+        with _patched(*_disable_all_boosts(), patch.object(settings.hybrid_search, "hybrid_alpha", 1.0)):
+            vector_result = await service.retrieve_memories(query=query, page_size=10)
+            vector_ids = get_result_ids(vector_result["memories"], k=10)
+
+        # Hybrid: alpha=None (adaptive), semantic_tag enabled for broader tag matching
+        with _patched(
+            patch.object(settings.salience, "enabled", False),
+            patch.object(settings.spaced_repetition, "enabled", False),
+            patch.object(settings.encoding_context, "enabled", False),
+            patch.object(settings.hybrid_search, "temporal_decay_lambda", 0.0),
+            patch.object(settings.hybrid_search, "recency_decay", 0.0),
+            patch.object(settings.hybrid_search, "hybrid_alpha", None),
+            patch.object(settings.intent, "enabled", False),
+        ):
+            hybrid_result = await service.retrieve_memories(query=query, page_size=10)
+            hybrid_ids = get_result_ids(hybrid_result["memories"], k=10)
+
+        assert (
+            vector_ids != hybrid_ids
+        ), "Hybrid RRF should produce different ordering than pure vector. If identical, tag matching had no effect."
+
+    @pytest.mark.asyncio
+    async def test_tag_only_results_have_base_score(self, service):
+        """Memories found only via tag matching (not vector) get TAG_ONLY_BASE_SCORE (0.1).
+        We verify no result drops below this floor when tags contribute."""
+        from mcp_memory_service.utils.hybrid_search import TAG_ONLY_BASE_SCORE
+
+        with _patched(
+            patch.object(settings.salience, "enabled", False),
+            patch.object(settings.spaced_repetition, "enabled", False),
+            patch.object(settings.encoding_context, "enabled", False),
+            patch.object(settings.hybrid_search, "temporal_decay_lambda", 0.0),
+            patch.object(settings.hybrid_search, "recency_decay", 0.0),
+            patch.object(settings.intent, "enabled", False),
+        ):
+            result = await service.retrieve_memories(query="fiction adventure epic", page_size=10)
+            for mem in result["memories"]:
+                score = mem["similarity_score"]
+                assert score >= TAG_ONLY_BASE_SCORE - 0.01, f"Score {score} below TAG_ONLY_BASE_SCORE ({TAG_ONLY_BASE_SCORE})"
+
+
+# ---------------------------------------------------------------------------
+# Class 3: Temporal Decay
+# ---------------------------------------------------------------------------
+
+
+class TestTemporalDecay:
+    """Tests temporal decay with controlled timestamps in an isolated storage."""
+
+    @pytest.fixture
+    async def decay_storage_and_service(self):
+        """Isolated storage with 4 identical-content memories at different ages.
+
+        Uses the same content (Machiavelli on leadership) but with timestamps
+        set to 1, 7, 30, and 90 days ago. This isolates the temporal variable.
+        """
+        storage = QdrantStorage(
+            storage_path=":memory:",
+            embedding_model="all-MiniLM-L6-v2",
+            collection_name=f"decay_{uuid.uuid4().hex[:8]}",
+        )
+        await storage.initialize()
+
+        now = time.time()
+        base_content = _SAMPLES_BY_ID["gutenberg_1232_1"]["content"]  # Machiavelli
+        ages_days = [1, 7, 30, 90]
+
+        for days in ages_days:
+            ts = now - (days * 86400)
+            memory = Memory(
+                content=base_content,
+                content_hash=f"decay_{days}d",
+                tags=["political-theory", "leadership"],
+                memory_type="reference",
+                created_at=ts,
+                updated_at=ts,
+            )
+            await storage.store(memory)
+
+        svc = MemoryService(storage, graph_client=None)
+        yield storage, svc, ages_days
+        await storage.close()
+
+    @pytest.mark.asyncio
+    async def test_recent_memory_scores_higher(self, decay_storage_and_service):
+        """With temporal decay enabled, the 1-day-old memory should outscore
+        the 90-day-old one, even though content is identical."""
+        _, svc, _ = decay_storage_and_service
+        with _patched(
+            *_disable_all_boosts(),
+            patch.object(settings.hybrid_search, "temporal_decay_lambda", 0.01),
+            patch.object(settings.hybrid_search, "temporal_decay_base", 0.7),
+        ):
+            result = await svc.retrieve_memories(query="leadership cruelty mercy political power", page_size=10)
+            memories = result["memories"]
+
+            score_1d = get_result_score(memories, "decay_1d")
+            score_90d = get_result_score(memories, "decay_90d")
+
+            assert score_1d is not None, "1-day-old memory not found in results"
+            assert score_90d is not None, "90-day-old memory not found in results"
+            assert score_1d > score_90d, f"1-day score ({score_1d:.4f}) should exceed 90-day score ({score_90d:.4f})"
+
+    @pytest.mark.asyncio
+    async def test_decay_factor_mathematically_correct(self, decay_storage_and_service):
+        """Verify the decay factor matches the formula:
+        factor = base + exp(-lambda * days) * (1 - base)
+        within a tolerance of 0.05."""
+        _, svc, _ = decay_storage_and_service
+        lam = 0.01
+        base = 0.7
+
+        with _patched(
+            *_disable_all_boosts(),
+            patch.object(settings.hybrid_search, "temporal_decay_lambda", lam),
+            patch.object(settings.hybrid_search, "temporal_decay_base", base),
+        ):
+            result = await svc.retrieve_memories(query="leadership cruelty mercy political power", page_size=10)
+            memories = result["memories"]
+
+            scores = {}
+            for m in memories:
+                scores[m["content_hash"]] = m["similarity_score"]
+
+            assert "decay_1d" in scores, "1-day-old memory not found in results"
+            assert "decay_90d" in scores, "90-day-old memory not found in results"
+            assert scores["decay_90d"] > 0, f"90-day score must be positive, got {scores['decay_90d']}"
+
+            expected_factor_1d = base + math.exp(-lam * 1) * (1 - base)
+            expected_factor_90d = base + math.exp(-lam * 90) * (1 - base)
+            expected_ratio = expected_factor_1d / expected_factor_90d
+            actual_ratio = scores["decay_1d"] / scores["decay_90d"]
+
+            assert (
+                abs(actual_ratio - expected_ratio) / expected_ratio < 0.05
+            ), f"Decay ratio mismatch: actual={actual_ratio:.4f}, expected={expected_ratio:.4f}"
+
+    @pytest.mark.asyncio
+    async def test_decay_disabled_no_score_reduction(self, decay_storage_and_service):
+        """With lambda=0, temporal decay is disabled and all identical-content
+        memories should have approximately equal scores."""
+        _, svc, _ = decay_storage_and_service
+        with _patched(
+            *_disable_all_boosts(),
+            patch.object(settings.hybrid_search, "temporal_decay_lambda", 0.0),
+            patch.object(settings.hybrid_search, "recency_decay", 0.0),
+        ):
+            result = await svc.retrieve_memories(query="leadership cruelty mercy political power", page_size=10)
+            memories = result["memories"]
+
+            scores = [m["similarity_score"] for m in memories if m["content_hash"].startswith("decay_")]
+
+            assert len(scores) >= 2, "Expected at least 2 decay memories in results"
+
+            max_score = max(scores)
+            min_score = min(scores)
+            assert (
+                max_score - min_score < 0.01
+            ), f"Score spread too large with decay disabled: max={max_score:.4f}, min={min_score:.4f}"
+
+    @pytest.mark.asyncio
+    async def test_scores_valid_after_decay(self, decay_storage_and_service):
+        """All scores must remain in [0.0, 1.0] after temporal decay is applied."""
+        _, svc, _ = decay_storage_and_service
+        with _patched(
+            *_disable_all_boosts(),
+            patch.object(settings.hybrid_search, "temporal_decay_lambda", 0.05),
+            patch.object(settings.hybrid_search, "temporal_decay_base", 0.7),
+        ):
+            result = await svc.retrieve_memories(query="leadership cruelty mercy political power", page_size=10)
+            for mem in result["memories"]:
+                score = mem["similarity_score"]
+                assert 0.0 <= score <= 1.0, f"Score {score} out of range after decay"
+
+
+# ---------------------------------------------------------------------------
+# Class 4: Salience Boost
+# ---------------------------------------------------------------------------
+
+
+class TestSalienceBoost:
+    """Tests salience-based score boosting with controlled salience values.
+
+    Uses two Darwin passages (very similar domain/content, near-equal base scores)
+    at salience 0.0 and 1.0, plus one Frankenstein passage at 0.5. The Darwin pair
+    isolates the salience variable for the core high-vs-low assertion.
+    """
+
+    @pytest.fixture
+    async def salience_storage_and_service(self):
+        """Isolated storage with related science passages at different salience levels."""
+        storage = QdrantStorage(
+            storage_path=":memory:",
+            embedding_model="all-MiniLM-L6-v2",
+            collection_name=f"salience_{uuid.uuid4().hex[:8]}",
+        )
+        await storage.initialize()
+
+        passages = [
+            ("salience_low", _SAMPLES_BY_ID["gutenberg_2009_1"]["content"], 0.0),  # Darwin: natural selection
+            ("salience_mid", _SAMPLES_BY_ID["gutenberg_84_1"]["content"], 0.5),  # Frankenstein: scientific discovery
+            ("salience_high", _SAMPLES_BY_ID["gutenberg_2009_2"]["content"], 1.0),  # Darwin: extinction/divergence
+        ]
+
+        for hash_id, content, salience in passages:
+            memory = Memory(
+                content=content,
+                content_hash=hash_id,
+                tags=["science", "19th-century"],
+                memory_type="reference",
+                salience_score=salience,
+                metadata={"importance": salience},
+            )
+            await storage.store(memory)
+
+        svc = MemoryService(storage, graph_client=None)
+        yield storage, svc
+        await storage.close()
+
+    @pytest.mark.asyncio
+    async def test_high_salience_outranks_low(self, salience_storage_and_service):
+        """With salience boost enabled, the high-salience Darwin passage should
+        rank above the low-salience Darwin passage. Both have near-equal base
+        scores for a Darwin-focused query, so salience is the differentiator."""
+        _, svc = salience_storage_and_service
+        with _patched(
+            *_disable_all_boosts(),
+            patch.object(settings.salience, "enabled", True),
+            patch.object(settings.salience, "boost_weight", 0.15),
+        ):
+            result = await svc.retrieve_memories(query="natural selection evolution biology", page_size=10, tags=[])
+            memories = result["memories"]
+
+            assert_ranks_above(memories, "salience_high", "salience_low")
+
+    @pytest.mark.asyncio
+    async def test_boost_proportional_to_salience(self, salience_storage_and_service):
+        """The boost delta should be proportional to salience_score.
+        High-salience (1.0) should get a larger relative boost than mid (0.5)."""
+        _, svc = salience_storage_and_service
+
+        # Baseline scores (no salience boost)
+        with _patched(*_disable_all_boosts()):
+            baseline = await svc.retrieve_memories(
+                query="science biology natural world evolution discovery", page_size=10, tags=[]
+            )
+            base_mid = get_result_score(baseline["memories"], "salience_mid")
+            base_high = get_result_score(baseline["memories"], "salience_high")
+
+        # Boosted scores
+        with _patched(
+            *_disable_all_boosts(),
+            patch.object(settings.salience, "enabled", True),
+            patch.object(settings.salience, "boost_weight", 0.15),
+        ):
+            boosted = await svc.retrieve_memories(
+                query="science biology natural world evolution discovery", page_size=10, tags=[]
+            )
+            boosted_mid = get_result_score(boosted["memories"], "salience_mid")
+            boosted_high = get_result_score(boosted["memories"], "salience_high")
+
+        assert base_mid is not None, "salience_mid not found in baseline results"
+        assert base_high is not None, "salience_high not found in baseline results"
+        assert boosted_mid is not None, "salience_mid not found in boosted results"
+        assert boosted_high is not None, "salience_high not found in boosted results"
+        assert base_mid > 0, f"base_mid score must be positive, got {base_mid}"
+        assert base_high > 0, f"base_high score must be positive, got {base_high}"
+
+        delta_mid = boosted_mid - base_mid
+        delta_high = boosted_high - base_high
+        relative_mid = delta_mid / base_mid
+        relative_high = delta_high / base_high
+        assert (
+            relative_mid < relative_high
+        ), f"Mid relative boost ({relative_mid:.4f}) should be less than high relative boost ({relative_high:.4f})"
+
+    @pytest.mark.asyncio
+    async def test_salience_disabled_no_effect_on_ranking(self, salience_storage_and_service):
+        """With salience disabled, ranking is determined only by content similarity.
+        The two Darwin passages should have similar scores since they're in the
+        same domain, regardless of their different salience_score values."""
+        _, svc = salience_storage_and_service
+        with _patched(*_disable_all_boosts()):
+            result = await svc.retrieve_memories(query="natural selection evolution survival biology", page_size=10, tags=[])
+            memories = result["memories"]
+
+            score_low = get_result_score(memories, "salience_low")
+            score_high = get_result_score(memories, "salience_high")
+
+            assert score_low is not None, "Low-salience Darwin memory not found"
+            assert score_high is not None, "High-salience Darwin memory not found"
+            # Both Darwin passages: similar content → similar scores when salience off
+            assert (
+                abs(score_low - score_high) < 0.10
+            ), f"Darwin pair score gap too large with salience off: low={score_low:.4f}, high={score_high:.4f}"
+
+    @pytest.mark.asyncio
+    async def test_salience_boost_weight_respected(self, salience_storage_and_service):
+        """The boost_weight parameter should control the magnitude.
+        weight=0.3 should produce a higher score than weight=0.15 for high-salience."""
+        _, svc = salience_storage_and_service
+
+        with _patched(
+            *_disable_all_boosts(),
+            patch.object(settings.salience, "enabled", True),
+            patch.object(settings.salience, "boost_weight", 0.15),
+        ):
+            result_015 = await svc.retrieve_memories(query="natural selection evolution biology", page_size=10, tags=[])
+            score_015 = get_result_score(result_015["memories"], "salience_high")
+
+        with _patched(
+            *_disable_all_boosts(),
+            patch.object(settings.salience, "enabled", True),
+            patch.object(settings.salience, "boost_weight", 0.30),
+        ):
+            result_030 = await svc.retrieve_memories(query="natural selection evolution biology", page_size=10, tags=[])
+            score_030 = get_result_score(result_030["memories"], "salience_high")
+
+        assert score_015 is not None, "salience_high not found in weight=0.15 results"
+        assert score_030 is not None, "salience_high not found in weight=0.30 results"
+        assert (
+            score_030 > score_015
+        ), f"boost_weight=0.30 score ({score_030:.4f}) should exceed boost_weight=0.15 score ({score_015:.4f})"
+
+
+# ---------------------------------------------------------------------------
+# Class 5: Query Intent Fan-out
+# ---------------------------------------------------------------------------
+
+
+def _has_spacy() -> bool:
+    """Check if spaCy and en_core_web_sm are available for intent analysis."""
+    try:
+        import spacy
+
+        spacy.load("en_core_web_sm")
+        return True
+    except Exception:
+        return False
+
+
+class TestQueryIntentFanout:
+    """Tests multi-concept query expansion (requires spaCy for full fan-out)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(not _has_spacy(), reason="spaCy en_core_web_sm not installed")
+    async def test_multi_concept_query_spans_clusters(self, service):
+        """A multi-concept query like 'leadership philosophy and scientific method'
+        should retrieve from multiple thematic clusters."""
+        with _patched(*_disable_all_boosts(), patch.object(settings.intent, "enabled", True)):
+            result = await service.retrieve_memories(
+                query="leadership philosophy and the scientific method of observation",
+                page_size=10,
+            )
+            memories = result["memories"]
+            top_ids = set(get_result_ids(memories, k=10))
+
+            has_political = bool(top_ids & POLITICAL_IDS)
+            has_science = bool(top_ids & SCIENCE_IDS)
+
+            # Fan-out must span BOTH clusters, not just the best single-vector match
+            assert has_political and has_science, (
+                f"Multi-concept query should hit BOTH clusters. "
+                f"Political: {has_political}, Science: {has_science}. Got: {top_ids}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_single_concept_returns_focused_results(self, service):
+        """A short query (below min_query_tokens=3) bypasses fan-out and returns
+        tightly focused results via a single vector search."""
+        with _patched(*_disable_all_boosts(), patch.object(settings.intent, "enabled", True)):
+            result = await service.retrieve_memories(query="stoic virtue", page_size=10)
+            memories = result["memories"]
+
+            top_ids = set(get_result_ids(memories, k=10))
+            stoic_hits = top_ids & AURELIUS_IDS
+            assert len(stoic_hits) >= 2, f"Expected >=2 Aurelius results for focused query, got {len(stoic_hits)}"
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(not _has_spacy(), reason="spaCy en_core_web_sm not installed")
+    async def test_multi_concept_covers_more_themes(self, service):
+        """Multi-concept results should cover more unique tag categories than
+        a single-concept query of comparable length."""
+        with _patched(*_disable_all_boosts(), patch.object(settings.intent, "enabled", True)):
+            multi = await service.retrieve_memories(
+                query="ancient philosophy about virtue combined with modern scientific discovery",
+                page_size=10,
+            )
+            single = await service.retrieve_memories(
+                query="ancient philosophy about virtue and reason",
+                page_size=10,
+            )
+
+            multi_tags = get_themes(multi["memories"], k=10)
+            single_tags = get_themes(single["memories"], k=10)
+
+            assert len(multi_tags) >= len(
+                single_tags
+            ), f"Multi-concept tags ({len(multi_tags)}) should >= single-concept ({len(single_tags)})"
+
+    @pytest.mark.asyncio
+    async def test_fanout_respects_min_similarity(self, service):
+        """Results from fan-out path should still respect min_similarity threshold."""
+        with _patched(*_disable_all_boosts(), patch.object(settings.intent, "enabled", True)):
+            result = await service.retrieve_memories(
+                query="leadership philosophy and scientific method of observation",
+                page_size=10,
+                min_similarity=0.3,
+            )
+            for mem in result["memories"]:
+                assert mem["similarity_score"] >= 0.3 - 0.01, f"Score {mem['similarity_score']:.4f} below min_similarity=0.3"
+
+
+# ---------------------------------------------------------------------------
+# Class 6: Full Pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestFullPipeline:
+    """All features enabled (except FalkorDB graph). End-to-end correctness."""
+
+    @pytest.mark.asyncio
+    async def test_full_pipeline_quality_at_least_baseline(self, service):
+        """Full pipeline results should return relevant results for core queries.
+        We verify that each query produces a non-trivial hit rate against a
+        broad set of plausible expected IDs."""
+        queries_and_expected = [
+            ("leadership and power", MACHIAVELLI_IDS | GOVERNANCE_IDS),
+            ("the sea and adventure", MELVILLE_IDS | CONRAD_IDS | {"gutenberg_345_1"}),
+            ("philosophy and virtue", PHILOSOPHY_IDS),
+        ]
+
+        with _patched(*_full_pipeline_patches()):
+            for query, expected in queries_and_expected:
+                result = await service.retrieve_memories(query=query, page_size=10)
+                top = set(get_result_ids(result["memories"], k=10))
+                hits = top & expected
+                assert len(hits) >= 1, f"Query '{query}': no hits in top 10. Expected any of {expected}, got {top}"
+
+    @pytest.mark.asyncio
+    async def test_no_score_exceeds_one(self, service):
+        """Score cap must ensure no result exceeds 1.0 after all boosts."""
+        with _patched(*_full_pipeline_patches()):
+            for query in ["leadership", "philosophy virtue", "scientific discovery"]:
+                result = await service.retrieve_memories(query=query, page_size=10)
+                for mem in result["memories"]:
+                    assert mem["similarity_score"] <= 1.0 + 1e-9, f"Score {mem['similarity_score']:.6f} exceeds 1.0 cap"
+
+    @pytest.mark.asyncio
+    async def test_min_similarity_filters_low_relevance(self, service):
+        """min_similarity=0.4 should filter out genuinely low-relevance results."""
+        with _patched(*_full_pipeline_patches()):
+            result = await service.retrieve_memories(
+                query="time travel and the fourth dimension",
+                page_size=10,
+                min_similarity=0.4,
+            )
+            for mem in result["memories"]:
+                assert mem["similarity_score"] >= 0.4 - 0.01, f"Score {mem['similarity_score']:.4f} below min_similarity=0.4"
+
+    @pytest.mark.asyncio
+    async def test_pagination_no_overlapping_hashes(self, service):
+        """Page 1 and page 2 results should have no overlapping content_hashes."""
+        with _patched(*_full_pipeline_patches()):
+            page1 = await service.retrieve_memories(query="philosophy and human nature", page=1, page_size=5)
+            page2 = await service.retrieve_memories(query="philosophy and human nature", page=2, page_size=5)
+
+            ids_1 = set(get_result_ids(page1["memories"], k=5))
+            ids_2 = set(get_result_ids(page2["memories"], k=5))
+
+            overlap = ids_1 & ids_2
+            assert not overlap, f"Pages 1 and 2 share {len(overlap)} results: {overlap}"
+
+    @pytest.mark.asyncio
+    async def test_empty_query_returns_graceful_result(self, service):
+        """An empty query should return an empty result or error, not crash."""
+        with _patched(*_full_pipeline_patches()):
+            result = await service.retrieve_memories(query="", page_size=10)
+            assert "memories" in result or "error" in result, "Empty query should return dict with 'memories' or 'error' key"
+
+
+# ---------------------------------------------------------------------------
+# Class 7: Performance
+# ---------------------------------------------------------------------------
+
+
+class TestPerformance:
+    """Latency and throughput tests. Generous thresholds for CI (CPU only)."""
+
+    @pytest.mark.asyncio
+    async def test_single_query_latency(self, service):
+        """A single query should complete in under 500ms.
+        Generous bound: includes embedding generation + Qdrant search + pipeline."""
+        with _patched(*_disable_all_boosts()):
+            # Warm up (first query loads model)
+            await service.retrieve_memories(query="warmup", page_size=1)
+
+            start = time.perf_counter()
+            await service.retrieve_memories(query="leadership and power", page_size=10)
+            elapsed_ms = (time.perf_counter() - start) * 1000
+
+            assert elapsed_ms < 500, f"Single query took {elapsed_ms:.0f}ms, expected < 500ms"
+
+    @pytest.mark.asyncio
+    async def test_sequential_query_p95(self, service):
+        """50 sequential queries, p95 latency should be under 1 second.
+        Tests that there are no per-query resource leaks or cold-start penalties."""
+        with _patched(*_disable_all_boosts()):
+            queries = [
+                "leadership and power",
+                "scientific discovery",
+                "the sea and adventure",
+                "philosophy and virtue",
+                "art and beauty",
+                "natural rights and liberty",
+                "observation and deduction",
+                "revolution and social upheaval",
+                "monsters and heroism",
+                "mental health and confinement",
+            ]
+
+            # Warm up
+            await service.retrieve_memories(query="warmup", page_size=1)
+
+            latencies = []
+            for i in range(50):
+                query = queries[i % len(queries)]
+                start = time.perf_counter()
+                await service.retrieve_memories(query=query, page_size=10)
+                elapsed_ms = (time.perf_counter() - start) * 1000
+                latencies.append(elapsed_ms)
+
+            latencies.sort()
+            p95_idx = int(0.95 * len(latencies))
+            p95 = latencies[p95_idx]
+
+            assert p95 < 1000, f"p95 latency is {p95:.0f}ms, expected < 1000ms"
+
+    @pytest.mark.asyncio
+    async def test_seeding_latency(self):
+        """Seeding 41 memories (embedding generation + storage) should complete
+        in under 60 seconds on CPU."""
+        start = time.perf_counter()
+
+        storage = QdrantStorage(
+            storage_path=":memory:",
+            embedding_model="all-MiniLM-L6-v2",
+            collection_name=f"perf_{uuid.uuid4().hex[:8]}",
+        )
+        await storage.initialize()
+
+        for sample in GOLDEN_SAMPLES:
+            memory = Memory(
+                content=sample["content"],
+                content_hash=sample["id"],
+                tags=sample.get("tags", []),
+                memory_type=sample.get("memory_type", "reference"),
+            )
+            await storage.store(memory)
+
+        elapsed_s = time.perf_counter() - start
+        await storage.close()
+
+        assert elapsed_s < 60, f"Seeding 41 memories took {elapsed_s:.1f}s, expected < 60s"


### PR DESCRIPTION
## Summary

Golden-sample integration tests that seed 41 Project Gutenberg passages into Qdrant `:memory:` with real embeddings, then validate every search pipeline stage end-to-end:

- **Baseline semantic** — pure vector search quality (Machiavelli, Darwin, Melville/Conrad)
- **Tag matching** — RRF re-ranking changes ordering vs pure vector
- **Temporal decay** — recent memories score higher, decay formula verified mathematically
- **Salience boost** — high-salience outranks low, proportional to weight, disabled = no effect
- **Query intent fan-out** — multi-concept queries span multiple thematic clusters (requires spaCy)
- **Full pipeline** — all features compose, scores capped at 1.0, pagination non-overlapping
- **Performance** — single query <500ms, p95 of 50 queries <1s, 41-memory seeding <60s

### Design decisions
- \`all-MiniLM-L6-v2\` (384-dim) for fast CI-friendly embeddings
- \`_patched()\` context manager via \`ExitStack\` eliminates ~25 try/finally blocks
- Isolated fixtures per test class prevent cross-test contamination
- spaCy-dependent fan-out tests skip gracefully when \`en_core_web_sm\` unavailable
- \`min_similarity\` left as default \`None\` in salience tests to avoid filtering negative cosine scores

## Test plan

- [x] All 27 tests pass, 2 skip (spaCy not installed)
- [x] Lint + format clean (ruff)
- [x] Rebased cleanly onto current main (single commit)
- [x] No changes to production code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive golden-sample integration tests validating the full search pipeline (semantic search, tag boosting/fallbacks, temporal decay, salience boosts, query-intent fan‑out, pagination, score capping) using realistic literary samples; includes fixtures, assertion helpers and performance checks.

* **Documentation**
  * Added a design doc describing the golden-sample test plan, fixture format, test structure, assertion strategies and Phase 1 scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->