### PR TITLE
fix: split Dockerfile model prewarm to prevent cascade failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,21 @@ RUN uv venv && \
 COPY src/ ./src/
 RUN uv pip install --no-deps -e .
 
-# Pre-download spaCy model, embedding model, and clean up in the same layer
-RUN uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl && \
-    .venv/bin/python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('${EMBEDDING_MODEL}')" && \
-    rm -rf /root/.cache/pip /root/.cache/uv && \
+# Pre-download embedding model (HuggingFace - reliable)
+RUN .venv/bin/python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('${EMBEDDING_MODEL}')"
+
+# Pre-download spaCy model (GitHub releases - can be flaky, retry up to 3 times).
+# spaCy is optional: if this fails the runtime falls back to FallbackAnalyzer for
+# query intent analysis. We still want it for better multi-concept fan-out.
+RUN for attempt in 1 2 3; do \
+        uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl \
+        && break \
+        || if [ "$attempt" -lt 3 ]; then echo "spaCy download attempt $attempt failed, retrying in 5s..."; sleep 5; \
+           else echo "spaCy download failed after 3 attempts, skipping (optional)"; fi; \
+    done
+
+# Clean up caches to reduce layer size
+RUN rm -rf /root/.cache/pip /root/.cache/uv && \
     find .venv -name "*.pyc" -delete 2>/dev/null || true && \
     find .venv -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

- Split the single `RUN` that downloaded both spaCy and HuggingFace models into independent steps
- HuggingFace embedding model prewarm runs first (reliable, creates `/root/.cache/huggingface`)
- spaCy model download runs second with 3 retries (GitHub releases are flaky)
- If all spaCy retries fail, build still succeeds — runtime falls back to `FallbackAnalyzer`

## Problem

The combined `RUN` step cascade-failed:
1. GitHub HTTP/2 stream refusal kills spaCy download
2. Entire `RUN` aborts before HuggingFace model gets prewarmed
3. `COPY --from=builder /root/.cache/huggingface` fails — directory never created

## Test plan

- [x] Local `docker build` succeeds
- [x] Both models present in built image
- [x] `uv pip install` has no native retry flag (verified) — shell loop is correct approach

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build reliability by splitting model preparation into separate steps.
  * Added distinct pre-download steps for embedding and NLP models; NLP pre-download now uses a 3‑attempt retry with short delays and is optional with a runtime fallback.
  * Moved cache cleanup into a dedicated final step.
  * Clarified retry behaviour; runtime behaviour remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->