### PR TITLE
chore: remove redundant coderabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,0 @@
-# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
-language: en-AU
-reviews:
-  profile: assertive
-  request_changes_workflow: true
-  high_level_summary: true
-  auto_review:
-    enabled: true
-    drafts: false


### PR DESCRIPTION
Org-level config in 27b-io/.github now covers this repo. No need for a per-repo duplicate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed configuration settings related to code review automation and language preferences. The system will now revert to default configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->