### PR TITLE
fix: replace dead spreading-activation boost with graph injection

### DIFF
--- a/src/mcp_memory_service/services/memory_service.py
+++ b/src/mcp_memory_service/services/memory_service.py
@@ -1134,16 +1134,36 @@ class MemoryService:
                 result_hashes.append(item.content_hash)
                 result_memories.append(item)
 
-        # Apply spreading activation boost from graph layer
+        # Graph injection: fetch spreading-activation neighbors not already
+        # in results and splice them in.  spreading_activation() returns
+        # {neighbor_hash: activation} for nodes NOT in the seed set, so we
+        # fetch those memories and inject them rather than trying to boost
+        # seeds (which would always look up 0.0).
         graph_boosts = await self._compute_graph_boosts(result_hashes)
         if graph_boosts:
-            boost_weight = settings.falkordb.spreading_activation_boost
-            for result in results:
-                activation = graph_boosts.get(result["content_hash"], 0.0)
-                if activation > 0:
-                    result["similarity_score"] = result.get("similarity_score", 0.0) + boost_weight * activation
-                    result["graph_boost"] = activation
-            results.sort(key=lambda r: r.get("similarity_score", 0.0), reverse=True)
+            fused_set = set(result_hashes)
+            inject_candidates = sorted(
+                ((h, s) for h, s in graph_boosts.items() if h not in fused_set),
+                key=lambda x: x[1],
+                reverse=True,
+            )[:10]
+            if inject_candidates:
+                neighbor_hashes = [h for h, _ in inject_candidates]
+                try:
+                    neighbors = await self.storage.get_memories_batch(neighbor_hashes)
+                    min_existing = min((r.get("similarity_score", 0.0) for r in results), default=0.1)
+                    for memory in neighbors:
+                        activation = graph_boosts.get(memory.content_hash, 0.0)
+                        display_score = max(min_existing, activation)
+                        mem_dict = self._format_memory_response(memory)
+                        mem_dict["similarity_score"] = display_score
+                        mem_dict["graph_boost"] = activation
+                        results.append(mem_dict)
+                        result_hashes.append(memory.content_hash)
+                        result_memories.append(memory)
+                    results.sort(key=lambda r: r.get("similarity_score", 0.0), reverse=True)
+                except Exception as e:
+                    logger.warning(f"Graph injection fetch failed (non-fatal): {e}")
 
         # Apply Hebbian co-access boost (within-result mutual edges)
         hebbian_boosts = await self._compute_hebbian_boosts(result_hashes)
@@ -1814,19 +1834,13 @@ class MemoryService:
 
             # Boost stages below operate on and re-sort by cosine display scores,
             # not RRF rank. RRF determines initial ordering; boosts refine from there.
-            # Apply spreading activation boost from graph layer
+            #
+            # NOTE: Spreading activation boost was previously here but was dead code —
+            # _compute_graph_boosts returns {neighbor_hash: activation} for nodes NOT
+            # in the seed set, but the boost loop iterated over seeds (which are
+            # excluded from the result).  Graph injection above (_inject_graph_neighbors)
+            # is the correct mechanism: it fetches and splices neighbor memories.
             all_hashes = [m.content_hash for m, _, _ in combined]
-            graph_boosts = await self._compute_graph_boosts(all_hashes)
-            if graph_boosts:
-                boost_weight = settings.falkordb.spreading_activation_boost
-                boosted = []
-                for memory, score, debug_info in combined:
-                    activation = graph_boosts.get(memory.content_hash, 0.0)
-                    if activation > 0:
-                        score += boost_weight * activation
-                        debug_info = {**debug_info, "graph_boost": activation}
-                    boosted.append((memory, score, debug_info))
-                combined = sorted(boosted, key=lambda x: x[1], reverse=True)
 
             # Apply Hebbian co-access boost (within-result mutual edges)
             hebbian_boosts = await self._compute_hebbian_boosts(all_hashes)

--- a/tests/unit/test_spreading_activation.py
+++ b/tests/unit/test_spreading_activation.py
@@ -181,12 +181,18 @@ def _make_query_result(content_hash: str, score: float) -> MemoryQueryResult:
 
 
 class TestMemoryServiceGraphBoost:
-    """Tests for graph boost integration in MemoryService retrieval."""
+    """Tests for graph boost integration in MemoryService retrieval.
+
+    NOTE: spreading_activation() returns {neighbor_hash: activation} for nodes
+    NOT in the seed set (the Cypher uses AND NOT dst.content_hash IN $seeds).
+    The service layer injects these neighbors into the result set rather than
+    trying to boost seeds (which would always look up 0.0).
+    """
 
     @pytest.mark.asyncio
     @patch("mcp_memory_service.services.memory_service.settings")
     async def test_vector_results_boosted_by_graph(self, mock_settings):
-        """Vector search results get boosted by spreading activation scores."""
+        """Spreading activation neighbors get injected into results."""
         from mcp_memory_service.services.memory_service import MemoryService
 
         # Configure settings
@@ -209,12 +215,14 @@ class TestMemoryServiceGraphBoost:
                 _make_query_result("hash_c", 0.7),
             ]
         )
+        # Neighbor memory available for injection
+        mock_storage.get_memories_batch = AsyncMock(return_value=[_make_memory("hash_neighbor", "neighbor content")])
 
-        # Mock graph: hash_b is activated by hash_a's neighbors
+        # Mock graph: hash_neighbor is a neighbor discovered by spreading activation
         mock_graph = AsyncMock()
         mock_graph.spreading_activation = AsyncMock(
             return_value={
-                "hash_b": 0.4,  # hash_b gets boosted
+                "hash_neighbor": 0.8,  # neighbor gets injected
             }
         )
 
@@ -231,13 +239,13 @@ class TestMemoryServiceGraphBoost:
         )
 
         memories = result["memories"]
-        # hash_b should be boosted: 0.8 + 0.2 * 0.4 = 0.88
-        hash_b_result = next(m for m in memories if m["content_hash"] == "hash_b")
-        assert hash_b_result["similarity_score"] == pytest.approx(0.88)
-        assert hash_b_result["graph_boost"] == pytest.approx(0.4)
+        # hash_neighbor should be injected into results
+        neighbor_result = next((m for m in memories if m["content_hash"] == "hash_neighbor"), None)
+        assert neighbor_result is not None, "Neighbor should be injected into results"
+        assert neighbor_result["graph_boost"] == pytest.approx(0.8)
 
-        # hash_a should still be first (0.9, no boost)
-        assert memories[0]["content_hash"] == "hash_a"
+        # Original results should still be present
+        assert any(m["content_hash"] == "hash_a" for m in memories)
 
     @pytest.mark.asyncio
     @patch("mcp_memory_service.services.memory_service.settings")
@@ -280,7 +288,7 @@ class TestMemoryServiceGraphBoost:
     @pytest.mark.asyncio
     @patch("mcp_memory_service.services.memory_service.settings")
     async def test_graph_boost_reorders_results(self, mock_settings):
-        """A strong graph boost can reorder results."""
+        """A strongly activated neighbor appears near the top of results."""
         from mcp_memory_service.services.memory_service import MemoryService
 
         mock_falkordb = MagicMock()
@@ -300,12 +308,14 @@ class TestMemoryServiceGraphBoost:
                 _make_query_result("hash_b", 0.6),
             ]
         )
+        # Neighbor memory available for injection
+        mock_storage.get_memories_batch = AsyncMock(return_value=[_make_memory("hash_neighbor", "strongly connected neighbor")])
 
-        # hash_b gets a strong activation
+        # Neighbor gets strong activation, should be injected
         mock_graph = AsyncMock()
         mock_graph.spreading_activation = AsyncMock(
             return_value={
-                "hash_b": 0.8,  # 0.6 + 0.5*0.8 = 1.0
+                "hash_neighbor": 0.9,  # strong activation
             }
         )
 
@@ -320,9 +330,12 @@ class TestMemoryServiceGraphBoost:
         )
 
         memories = result["memories"]
-        # hash_b (1.0) now beats hash_a (0.7)
-        assert memories[0]["content_hash"] == "hash_b"
-        assert memories[0]["similarity_score"] == pytest.approx(1.0)
+        # Neighbor should be present in results
+        neighbor_hashes = [m["content_hash"] for m in memories]
+        assert "hash_neighbor" in neighbor_hashes, f"Neighbor should be injected. Got: {neighbor_hashes}"
+        # And should have its activation recorded
+        neighbor = next(m for m in memories if m["content_hash"] == "hash_neighbor")
+        assert neighbor["graph_boost"] == pytest.approx(0.9)
 
     @pytest.mark.asyncio
     @patch("mcp_memory_service.services.memory_service.settings")

--- a/tests/unit/test_spreading_activation.py
+++ b/tests/unit/test_spreading_activation.py
@@ -333,9 +333,12 @@ class TestMemoryServiceGraphBoost:
         # Neighbor should be present in results
         neighbor_hashes = [m["content_hash"] for m in memories]
         assert "hash_neighbor" in neighbor_hashes, f"Neighbor should be injected. Got: {neighbor_hashes}"
-        # And should have its activation recorded
+        # Activation recorded
         neighbor = next(m for m in memories if m["content_hash"] == "hash_neighbor")
         assert neighbor["graph_boost"] == pytest.approx(0.9)
+        # Neighbor (display_score=max(0.6, 0.9)=0.9) beats both seeds (0.7, 0.6)
+        assert memories[0]["content_hash"] == "hash_neighbor"
+        assert memories[0]["similarity_score"] > memories[1]["similarity_score"]
 
     @pytest.mark.asyncio
     @patch("mcp_memory_service.services.memory_service.settings")


### PR DESCRIPTION
## Summary

- **Spreading activation boost was dead code** in `_retrieve_vector_only` — `spreading_activation()` returns `{neighbor_hash: activation}` (seeds excluded via Cypher `NOT IN $seeds`), but the boost loop looked up seed hashes, always returning 0.0
- **Replaced with graph injection** — fetch up to 10 activated neighbors from Qdrant, splice into results with display score floored at min existing
- **Removed redundant dead boost in hybrid path** — `_inject_graph_neighbors` already handles graph injection correctly there
- **Updated 2 tests** that were testing impossible behavior (seed-boosting) to test injection behavior

## Context

Same bug fixed in 27b-io/alaya#16 (Rust). This repo's service layer is no longer in the active MCP search path (Alaya handles all MCP calls), but fixed for consistency and correctness.

## Test plan

- [x] 853 unit tests pass (`pytest tests/unit/`)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] 14/14 spreading activation tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Memory retrieval now injects contextually related neighbor memories into results, improving discovery of connected items.
  * Ranking updated so injected neighbors are appropriately ordered alongside original matches for clearer, more consistent results.

* **Tests**
  * Updated unit tests to verify neighbor injection and reordered result expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->